### PR TITLE
Add installation instructions for Fedora

### DIFF
--- a/docs/manual/install.rst
+++ b/docs/manual/install.rst
@@ -19,6 +19,17 @@ Alternatively, you can download the `PKGBUILD`_ file from the repo and run ``mak
 
 .. _PKGBUILD: https://raw.githubusercontent.com/elParaguayo/qtile-extras/main/PKGBUILD
 
+Fedora
+======
+
+There is no official package for Fedora yet but you can install it
+from `Copr`_::
+
+    dnf copr enable frostyx/qtile
+    dnf install qtile-extras
+
+.. _Copr: https://copr.fedorainfracloud.org/
+
 Everyone else
 =============
 


### PR DESCRIPTION
I am currently maintaining Qtile package for Fedora in a Copr project since it was retired from the official repositories and trying to get it back (currently waiting for somebody to do a package review).

I am going to do the same for `qtile-extras`.