### PR TITLE
Fix regex bug in ALSAWidget

### DIFF
--- a/qtile_extras/widget/alsavolumecontrol.py
+++ b/qtile_extras/widget/alsavolumecontrol.py
@@ -6,7 +6,7 @@ from libqtile import bar, confreader, images
 from libqtile.log_utils import logger
 from libqtile.widget import base
 
-RE_VOL = re.compile(r"Playback\s[0-9]+\s\[([0-9]+)%\]\s\[(on|off)\]")
+RE_VOL = re.compile(r"Playback\s[0-9]+\s\[([0-9]+)%\].*\[(on|off)\]")
 
 
 class ALSAWidget(base._Widget, base.PaddingMixin, base.MarginMixin):

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ deps =
     iwlib
 # pywayland has to be installed before pywlroots
 commands =
-    pip install pywlroots>=0.13.4
+    pip install pywlroots>=0.14.1,<0.15.0
     pip install 'xcffib>=0.10.1'
     pip install --no-cache-dir cairocffi
     pip install git+https://github.com/qtile/qtile.git#egg=qtile-extras


### PR DESCRIPTION
Where amixer includes decibel levels in the output, the current regex will fail and so no volume will be recognised.

This PR fixes that by making the regex less strict.

Fixes #33