### PR TITLE
Remove docs test from CI

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -127,4 +127,4 @@ python =
     ; pypy-3.7: pypy3
     3.8: py38
     3.9: py39
-    3.10: py310, pep8, docs, print
+    3.10: py310, pep8, print


### PR DESCRIPTION
We're using ReadTheDocs webhook and status on pull requests now so no need for a separate test in CI.

`tox -e docs` is still available for local testing.