### PR TITLE
Fix tooltip only showing once

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,3 @@
+2022-03-05: [BUGFIX] Fix tooltip only showing once
 2022-03-05: [BUGFIX] Better handling of empty menus in StatusNotifier widget
 2022-01-09: [FEATURE] Add SnapCast widget (missing some functionality)

--- a/qtile_extras/widget/mixins/__init__.py
+++ b/qtile_extras/widget/mixins/__init__.py
@@ -133,6 +133,7 @@ class TooltipMixin(_BaseMixin):
     def _stop_tooltip(self, x, y):
         if self._tooltip_timer and not self._tooltip:
             self._tooltip_timer.cancel()
+            self._tooltip_timer = None
             return
 
         else:


### PR DESCRIPTION
I was trying to write a dynamic tooltip for `UPowerWidget` and noticed the tooltip was only showing up once. I figured out that it was because `self._tooltip_timer` still had a value in `_start_tooltip`, which requires it to be falsey. I have updated `_stop_tooltip` to explicitly set `_tooltip_timer` to `None`.