### PR TITLE
Allow RectDecoration to inherit colour from widget

### DIFF
--- a/test/widget/test_widget_decorations.py
+++ b/test/widget/test_widget_decorations.py
@@ -65,3 +65,39 @@ def test_decorations(manager_nospawn, minimal_conf_noscreen):
 
     _, decs = manager_nospawn.c.widget["scriptexit"].eval("len(self.decorations)")
     assert int(decs) == 3
+
+
+def test_rect_decoration_using_widget_background(manager_nospawn, minimal_conf_noscreen):
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar(
+                [
+                    widget.ScriptExit(
+                        name="one",
+                        background="ff0000",
+                        decorations=[RectDecoration(colour="00ff00")],
+                    ),
+                    widget.ScriptExit(
+                        name="two",
+                        background="ff0000",
+                        decorations=[RectDecoration(colour="00ff00", use_widget_background=True)],
+                    ),
+                ],
+                10,
+            )
+        )
+    ]
+
+    manager_nospawn.start(config)
+
+    manager_nospawn.c.bar["top"].eval("self.draw()")
+
+    _, one = manager_nospawn.c.widget["one"].eval("self.decorations[0].fill_colour")
+    _, two = manager_nospawn.c.widget["two"].eval("self.decorations[0].fill_colour")
+
+    # First widget's decoration is drawn using the decoration's colour
+    assert one == "00ff00"
+
+    # Second widget's decoration inherits the colour from the widget
+    assert two == "ff0000"


### PR DESCRIPTION
This PR allows the RectDecoration colour to be specified by the widget's background colour. This is helpful in two scenarios:

1) The same decoration config can be used for multiple widgets
2) Some widget's change colour depending on status so this change can be reflected in the decoration.