### PR TITLE
Better handling of empty menu in StatusNotifier

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,1 +1,2 @@
-2022-01-09: Add SnapCast widget (missing some functionality)
+2022-03-05: [BUGFIX] Better handling of empty menus in StatusNotifier widget
+2022-01-09: [FEATURE] Add SnapCast widget (missing some functionality)

--- a/qtile_extras/widget/statusnotifier.py
+++ b/qtile_extras/widget/statusnotifier.py
@@ -370,6 +370,9 @@ class StatusNotifier(QtileStatusNotifier):
         self.selected_item.get_menu()
 
     def display_menu(self, menu_items):
+        if not menu_items:
+            return
+
         self.menu = PopupMenu.from_dbus_menu(self.qtile, menu_items, **self.menu_config)
 
         screen = self.bar.screen


### PR DESCRIPTION
If there are no menu items, the widget shouldn't try to create a menu so we exit the function immediately.