### PR TITLE
Better handling of layout initialisation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-03-15: [BUGFIX] Ensure toolkit disables naviagation when no focusable controls (#49)
 2022-03-15: [DOCS] Fix docs build error (git --> https)
 2022-03-05: [GITHUB] Require PRs to update CHANGELOG
 2022-03-05: [BUGFIX] Fix tooltip only showing once

--- a/qtile_extras/popup/toolkit.py
+++ b/qtile_extras/popup/toolkit.py
@@ -92,12 +92,15 @@ class _PopupLayout(configurable.Configurable):
 
         # Identify focused control (via mouse of keypress)
         self.focusable_controls = [c for c in self.controls if c.can_focus]
-        if self.initial_focus is None:
+        if self.initial_focus is None or not self.focusable_controls:
             self._focused = None
-        elif self.focusable_controls:
-            self._focused = self.focusable_controls[self.initial_focus]
         else:
-            self._focused = None
+            try:
+                self._focused = self.focusable_controls[self.initial_focus]
+            except IndexError:
+                self._focused = self.focusable_controls[0]
+
+        if not self.focusable_controls:
             self.keyboard_navigation = False
 
         # Identify keysyms for keybaord navigation

--- a/test/popup/test_toolkit.py
+++ b/test/popup/test_toolkit.py
@@ -204,3 +204,35 @@ def test_grid_layout(manager):
     assert control["y"] == 0
     assert control["width"] == 150
     assert control["height"] == 100
+
+
+def test_disable_navigation():
+    """Where there are no focusable controls, keyboard navigation is disabled."""
+    controls = [
+        PopupText(
+            text="TEST",
+            row=0,
+            col=0,
+        ),
+    ]
+
+    layout = PopupGridLayout(
+        None, width=500, height=200, controls=controls, keyboard_navigation=True, initial_focus=0
+    )
+
+    assert not layout.keyboard_navigation
+    assert layout._focused is None
+
+
+def test_initial_focus_index_error():
+    """Where there are focusable controls but index is too high, default to first control."""
+    controls = [
+        PopupText(text="TEST", row=0, col=0, mouse_callbacks={"Button1": lambda: None}),
+    ]
+
+    layout = PopupGridLayout(
+        None, width=500, height=200, controls=controls, keyboard_navigation=True, initial_focus=1
+    )
+
+    assert layout._focused == controls[0]
+    assert layout.keyboard_navigation


### PR DESCRIPTION
Ensure that keyboard navigation is disabled when there are no focusable controls.

Fixes #49