### PR TITLE
Fix docs build error

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-03-15: [DOCS] Fix docs build error (git --> https)
 2022-03-05: [GITHUB] Require PRs to update CHANGELOG
 2022-03-05: [BUGFIX] Fix tooltip only showing once
 2022-03-05: [BUGFIX] Better handling of empty menus in StatusNotifier widget

--- a/docs/rtd_requirements.txt
+++ b/docs/rtd_requirements.txt
@@ -1,2 +1,2 @@
 cairocffi
-git+git://github.com/qtile/qtile@master#egg=qtile
+git+https://github.com/qtile/qtile.git@master#egg=qtile


### PR DESCRIPTION
Builds fail with following message "The unauthenticated git protocol on port 9418 is no longer supported".

Replace git clone address with https.