### PR TITLE
Fix position of popups on multiple monitor setups

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-03-16: [BUGFIX] Better positioning of popups on multiscreen setups (#50)
 2022-03-15: [BUGFIX] Ensure toolkit disables naviagation when no focusable controls (#49)
 2022-03-15: [DOCS] Fix docs build error (git --> https)
 2022-03-05: [GITHUB] Require PRs to update CHANGELOG

--- a/qtile_extras/popup/toolkit.py
+++ b/qtile_extras/popup/toolkit.py
@@ -166,13 +166,26 @@ class _PopupLayout(configurable.Configurable):
             c.drawer.ctx.restore()
         self.popup.draw()
 
-    def show(self, x=0, y=0, centered=False, warp_pointer=False):
+    def show(self, x=None, y=None, centered=False, warp_pointer=False):
         """Display the popup. Can be centered on screen."""
         if not self.configured:
             self._configure()
+        if x is None:
+            x = self.qtile.current_screen.x
+
+        if y is None:
+            y = self.qtile.current_screen.y
+
         if centered:
-            x = int((self.qtile.current_screen.width - self.popup.width) / 2)
-            y = int((self.qtile.current_screen.height - self.popup.height) / 2)
+            x = (
+                int((self.qtile.current_screen.width - self.popup.width) / 2)
+                + self.qtile.current_screen.x
+            )
+            y = (
+                int((self.qtile.current_screen.height - self.popup.height) / 2)
+                + self.qtile.current_screen.y
+            )
+
         self.popup.x = x
         self.popup.y = y
         self.popup.place()


### PR DESCRIPTION
Previous code did not take account of x and y offsets for multiple monitors so popups were always placed relative the (0, 0) origin.

This PR defaults to placing the window on the current screen but the popup can be placed anywhere by using absolute x and y coordinates.

Fixes #50