### PR TITLE
Fix toolkit keyboard navigation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-06-28: [BUGFIX] Fix keyboard navigation for toolkit (must be on latest git version of qtile)
 2022-05-26: [CONFIG_BREAK] Use `foreground` to set font colour, rather than `font_colour`
 2022-05-08: [FEATURE] Add GlobalMenu widget (alpha version!)
 2022-05-08: [FEATURE] Add AnalogueClock widget

--- a/qtile_extras/popup/toolkit.py
+++ b/qtile_extras/popup/toolkit.py
@@ -104,7 +104,7 @@ class _PopupLayout(configurable.Configurable):
             self.keyboard_navigation = False
 
         # Identify keysyms for keybaord navigation
-        self.keys = {k: [keysyms[key] for key in v] for k, v in self.keymap.items()}
+        self.keys = {k: [keysyms[key.lower()] for key in v] for k, v in self.keymap.items()}
 
         self.queued_draws = []
 


### PR DESCRIPTION
A commit introduced by https://github.com/qtile/qtile/pull/3647/ changed the keys in the keysyms dictionary to lower case. We therefore need to make sure the configuration for a popup is converted to lower case.