### PR TITLE
Fix wordclock crash

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-07-02: [BUGFIX] Fix WordClock crash at certain times
 2022-07-01: [FEATURE] Add CurrentLayoutIcon widget (with colour icons)
 2022-06-28: [FEATURE] Add GithubNotifications widget
 2022-06-28: [BUGFIX] Fix keyboard navigation for toolkit (must be on latest git version of qtile)

--- a/qtile_extras/widget/wordclock.py
+++ b/qtile_extras/widget/wordclock.py
@@ -111,7 +111,7 @@ class WordClock(base._Widget):
         # Is our language one where we need to increment the hour after 30 mins
         # e.g. 9:40 is "Twenty to ten"
         if self.config.HOUR_INCREMENT and (minute > self.config.HOUR_INCREMENT_TIME):
-            hour += 1
+            hour = (hour + 1) % 24
 
         # Use a time object so we can use string formatting for the time.
         tm = time(hour, minute)


### PR DESCRIPTION
If it's 23 hours and the hour increment is triggered then we get a value of 24 which causes the `datetime.time` conversion to crash as hours must be in the 0 to 23 range.