### PR TITLE
UPower widget doesn't show text if fontsize is unset.

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-07-07: [BUGFIX] Fix UPowerWidget not showing text on click when fontsize is None
 2022-07-03: [PACKAGING] Use git versioning details
 2022-07-03: [BUGFIX] Fix scaling on CurrentLayoutIcon and disable `use_mask=True` default
 2022-07-02: [PACKAGING] Fix missing files in package

--- a/qtile_extras/widget/upower.py
+++ b/qtile_extras/widget/upower.py
@@ -129,6 +129,8 @@ class UPowerWidget(base._Widget):
             (100, "Normal"),
         ]
         self.borders = {True: self.border_charge_colour, False: self.border_colour}
+        if self.fontsize is None:
+            self.fontsize = self.bar.height - self.bar.height / 5
 
     async def _config_async(self):
         await self._setup_dbus()

--- a/test/widget/test_network.py
+++ b/test/widget/test_network.py
@@ -25,7 +25,13 @@ import libqtile.confreader
 import libqtile.layout
 import pytest
 
-import qtile_extras.widget.network
+try:
+    import qtile_extras.widget.network
+except ImportError as e:
+    if "iwlib" in str(e):
+        pytest.skip("No iwlib installed", allow_module_level=True)
+    else:
+        raise e
 
 
 def get_status(interface):

--- a/test/widget/test_upower.py
+++ b/test/widget/test_upower.py
@@ -160,7 +160,9 @@ def test_upower_charging(manager_nospawn, powerconfig):
 
 @upower_dbus_servive
 @pytest.mark.parametrize(
-    "powerconfig", [{"battery_name": "BAT1", "text_displaytime": 0.5}], indirect=True
+    "powerconfig",
+    [{"battery_name": "BAT1", "text_displaytime": 0.5, "fontsize": None}],
+    indirect=True,
 )
 def test_upower_show_text(manager_nospawn, powerconfig):
     manager_nospawn.start(powerconfig)


### PR DESCRIPTION
This PR makes it behave like all TextBox widgets.

I've also made the network widget tests optional, I don't have iwlib available on Debian and didn't want to build from source.
