### PR TITLE
Add `fill_charge` parameter for UPower widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,5 @@
-2022-07-21: [BUGFIX] Fux CurrentLayoutIcon to work with latest git version
+2022-07-27: [FEATURE] Add `fill_charge` to UPower widget
+2022-07-21: [BUGFIX] Fix CurrentLayoutIcon to work with latest git version
 2022-07-21: [BUGFIX] Fix blocking API calls in Snapcast and GithubNotification widgets
 2022-07-07: [BUGFIX] Fix UPowerWidget not showing text on click when fontsize is None
 2022-07-03: [PACKAGING] Use git versioning details

--- a/qtile_extras/widget/upower.py
+++ b/qtile_extras/widget/upower.py
@@ -64,6 +64,7 @@ class UPowerWidget(base._Widget):
         ("fill_normal", "dbdbe0", "Fill when normal"),
         ("fill_low", "aa00aa", "Fill colour when battery low"),
         ("fill_critical", "cc0000", "Fill when critically low"),
+        ("fill_charge", None, "Override fill colour when charging"),
         ("margin", 2, "Margin on sides of widget"),
         ("spacing", 5, "Space between batteries"),
         ("percentage_low", 0.20, "Low level threshold."),
@@ -289,9 +290,12 @@ class UPowerWidget(base._Widget):
             percentage = battery["fraction"]
 
             # Get the appropriate fill colour
-            # This finds the first value in self_colours which is greater than
-            # the current battery level and returns the colour string
-            fill = next(x[1] for x in self.colours if percentage <= x[0])
+            if self.charging and self.fill_charge:
+                fill = self.fill_charge
+            else:
+                # This finds the first value in self_colours which is greater than
+                # the current battery level and returns the colour string
+                fill = next(x[1] for x in self.colours if percentage <= x[0])
 
             # Choose border colour
             if (percentage <= self.percentage_critical) and not self.charging:


### PR DESCRIPTION
Default behaviour is to use standard colours but the PR allows users to override the default behaviour and set a fill colour for when the battery is charging.

Closes #85