### PR TITLE
Unsubscribe dbus signals in Upower widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-08-19: [BUGFIX] Unsubscribe signal callbacks in `Upower` widget on restart
 2022-08-19: [BUGFIX] Fix bug where `GlobalMenu` is not shown for current window after restart
 2022-08-19: [BUGFIX] Fix menu position for `StatusNotifier` for multiple monitors
 2022-08-18: [FEATURE] Add `PowerLineDecoration`

--- a/qtile_extras/widget/upower.py
+++ b/qtile_extras/widget/upower.py
@@ -142,8 +142,8 @@ class UPowerWidget(base._Widget):
         introspection = await self.bus.introspect(UPOWER_SERVICE, UPOWER_PATH)
         object = self.bus.get_proxy_object(UPOWER_SERVICE, UPOWER_PATH, introspection)
 
-        props = object.get_interface("org.freedesktop.DBus.Properties")
-        props.on_properties_changed(self.upower_change)
+        self.props = object.get_interface("org.freedesktop.DBus.Properties")
+        self.props.on_properties_changed(self.upower_change)
 
         self.upower = object.get_interface(UPOWER_INTERFACE)
 
@@ -390,3 +390,9 @@ class UPowerWidget(base._Widget):
         info["charging"] = self.charging
         info["levels"] = self.status
         return info
+
+    def finalize(self):
+        self.props.off_properties_changed(self.upower_change)
+        self.bus.disconnect()
+        self.bus = None
+        base._Widget.finalize(self)


### PR DESCRIPTION
Reloading config can cause multiple callbacks to be triggered giving undesirable behaviour.

This PR adds code to unsubscribe from signals and disconnect the bus object.

Fixes #92