### PR TITLE
Fix mouse_callbacks in WifiIcon widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-09-11: [BUGFIX] Fix mouse callback bug in `WifiIcon` widget
 2022-08-24: [BUGFIX] Better handling of popup finalisation
 2022-08-19: [BUGFIX] Unsubscribe signal callbacks in `Upower` widget on restart
 2022-08-19: [BUGFIX] Fix bug where `GlobalMenu` is not shown for current window after restart

--- a/qtile_extras/widget/network.py
+++ b/qtile_extras/widget/network.py
@@ -36,6 +36,8 @@ def to_rads(degrees):
 class WiFiIcon(base._Widget, base.PaddingMixin):
     """
     An simple graphical widget that shows WiFi status.
+
+    Left-clicking the widget will show the name of the network.
     """
 
     orientations = base.ORIENTATION_HORIZONTAL
@@ -66,6 +68,8 @@ class WiFiIcon(base._Widget, base.PaddingMixin):
         base._Widget.__init__(self, bar.CALCULATED, **config)
         self.add_defaults(WiFiIcon.defaults)
         self.add_defaults(base.PaddingMixin.defaults)
+
+        self.add_callbacks({"Button1": self.cmd_show_text})
 
         if "font_colour" in config:
             self.foreground = config["font_colour"]
@@ -189,12 +193,10 @@ class WiFiIcon(base._Widget, base.PaddingMixin):
 
         return width
 
-    def button_press(self, x, y, button):
-        # Check if it's a right click and, if so, toggle textt
-        if button == 1:
-            self.show_text = True
-            self.set_hide_timer()
-            self.bar.draw()
+    def cmd_show_text(self):
+        self.show_text = True
+        self.set_hide_timer()
+        self.bar.draw()
 
     def set_hide_timer(self):
         if self.hide_timer:

--- a/test/widget/test_network.py
+++ b/test/widget/test_network.py
@@ -86,6 +86,10 @@ def test_wifiicon(manager_nospawn, wifi_manager):
     manager_nospawn.c.widget["wifiicon"].eval("self.hide()")
     assert manager_nospawn.c.widget["wifiicon"].info()["width"] == 36
 
+    # Call exposed command to toggle text
+    manager_nospawn.c.widget["wifiicon"].show_text()
+    assert manager_nospawn.c.widget["wifiicon"].info()["width"] > 36
+
 
 def test_wifiicon_deprecated_font_colour(caplog):
     widget = qtile_extras.widget.network.WiFiIcon(font_colour="ffffff")


### PR DESCRIPTION
Bug didn't allow users to set mouse callbacks on other button press events. This has been fixed along with exposing a `show_text()` command to display the wifi network name.

Fixes #101