### PR TITLE
Bump pywlroots version to match qtile

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -43,7 +43,7 @@ deps =
 # pywayland has to be installed before pywlroots
 commands =
     pip install --force-reinstall --no-binary :all: cffi
-    pip install pywlroots>=0.15.17,<0.16.0
+    pip install pywlroots>=0.15.21,<0.16.0
     pip install 'xcffib>=0.10.1'
     pip install --no-cache-dir cairocffi
     pip install git+https://github.com/qtile/qtile.git#egg=qtile-extras


### PR DESCRIPTION
CI test suite needs this for Wayland tests to pass.