### PR TITLE
Add `extrawidth` to decorations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-10-04: [FEATURE] Allow users to add extra width at the end of a decoration.
 2022-10-04: [BUGFIX] Fix `Visualizer` image size bug
 2022-10-04: [TESTS] Pin `pytest-cov` to 3.0.0 to retain `multiprocessing` support
 2022-09-24: [BUGFIX] Improve icon background rendering in `Systray` with `RectDecoration`

--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -42,12 +42,15 @@ class _Decoration(base.PaddingMixin):
     configs directly.
     """
 
-    defaults = [("padding", 0, "Default padding")]  # type: list[tuple[str, Any, str]]
+    defaults = [
+        ("padding", 0, "Default padding"),
+        ("extrawidth", 0, "Add additional width to the end of the decoration"),
+    ]  # type: list[tuple[str, Any, str]]
 
     def __init__(self, **config):
         base.PaddingMixin.__init__(self, **config)
         self.add_defaults(_Decoration.defaults)
-        self._extrawidth = 0
+        self._extrawidth = self.extrawidth
 
     def __eq__(self, other):
         return type(self) == type(other) and self._user_config == other._user_config
@@ -530,7 +533,7 @@ class PowerLineDecoration(_Decoration):
         _Decoration.__init__(self, **config)
         self.add_defaults(PowerLineDecoration.defaults)
         self.shift = max(min(self.shift, self.size), 0)
-        self._extrawidth = self.size - self.shift
+        self._extrawidth += self.size - self.shift
 
     @property
     def parent_length(self):

--- a/test/widget/test_widget_decorations.py
+++ b/test/widget/test_widget_decorations.py
@@ -172,3 +172,39 @@ def test_powerline_decoration(manager_nospawn, minimal_conf_noscreen):
     # Widget four has a 'backwards' decoration so the background is the next widget and background is the current
     assert fg == "ffffff"  # widget five's background
     assert bg == "ff00ff"  # widget four's background
+
+
+def test_decoration_extrawidth(manager_nospawn, minimal_conf_noscreen):
+    config = minimal_conf_noscreen
+    config.screens = [
+        libqtile.config.Screen(
+            top=libqtile.bar.Bar(
+                [
+                    widget.Spacer(
+                        length=50,
+                        name="one",
+                        decorations=[PowerLineDecoration(size=10, extrawidth=10)],
+                    ),
+                    widget.Spacer(
+                        length=50,
+                        name="two",
+                        decorations=[RectDecoration(extrawidth=20)],
+                    ),
+                    widget.Spacer(
+                        length=50,
+                        name="three",
+                        background="00ffff",
+                        decorations=[BorderDecoration(extrawidth=30)],
+                    ),
+                ],
+                10,
+            )
+        )
+    ]
+
+    manager_nospawn.start(config)
+    manager_nospawn.c.bar["top"].eval("self.draw()")
+
+    assert manager_nospawn.c.widget["one"].info()["length"] == 70
+    assert manager_nospawn.c.widget["two"].info()["length"] == 70
+    assert manager_nospawn.c.widget["three"].info()["length"] == 80


### PR DESCRIPTION
This PR allows users to define an `extrawidth` property which will increase the width of the underlying widget. This is useful when the decoration cuts off widget's contents (notably with the `Systray` widget