### PR TITLE
Fix Visualiser size bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-10-04: [BUGFIX] Fix `Visualizer` image size bug
 2022-10-04: [TESTS] Pin `pytest-cov` to 3.0.0 to retain `multiprocessing` support
 2022-09-24: [BUGFIX] Improve icon background rendering in `Systray` with `RectDecoration`
 2022-02-22: [RELEASE] v0.22.1 (skipped v0.22.0)

--- a/qtile_extras/widget/visualiser.py
+++ b/qtile_extras/widget/visualiser.py
@@ -211,7 +211,7 @@ class Visualiser(base._Widget):
     def _draw(self):
         with self._take_lock(self._lock.buf):
             surface = cairocffi.ImageSurface.create_for_data(
-                self._shm.buf, cairocffi.FORMAT_ARGB32, self.width, self.bar_height
+                self._shm.buf, cairocffi.FORMAT_ARGB32, self._config_length, self.bar_height
             )
 
         self.drawer.clear(self.background or self.bar.background)


### PR DESCRIPTION
The Visualiser widget has a bug where, if the user is using a widget decoration, the widget expects a larger image size than it receives from the cava_draw script. This is because it bases the image size on the widget width, rather than the visualiser width.

Fixes #121