### PR TITLE
Fix IndexError on RectDecoration

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-10-05: [BUGFIX] Fix IndexError on grouped `RectDecoration` (issue #126)
 2022-10-04: [BUGFIX] Fix `extrawidth` with `PowerlineDecoration`
 2022-10-04: [FEATURE] Allow users to add extra width at the end of a decoration.
 2022-10-04: [BUGFIX] Fix `Visualizer` image size bug

--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -275,7 +275,7 @@ class RectDecoration(_Decoration):
             self.ctx.rectangle(self.padding_x, self.padding_y, box_width, box_height)
 
         else:
-            if self.group:
+            if self.group and self.parent in self.parent.bar.widgets:
 
                 corners = [0, 0, 0, 0]
 


### PR DESCRIPTION
Grouped decorations look up their position in the bar. This can cause issues when the widget is inside a WidgerBox.

This PR addresses the issue by only allowing grouping when the widget is in the parent bar (i.e. visible).

Fixes #126