### PR TITLE
Fix `RectDecoration` reload bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-10-15: [BUGFIX] Fix `RectDecoration` reload bug with `use_widget_background`
 2022-10-10: [UPSTREAM] Change command syntax to match changes to qtile codebase (needs latest git version of qtile)
 2022-10-05: [BUGFIX] Fix IndexError on grouped `RectDecoration` (issue #126)
 2022-10-04: [BUGFIX] Fix `extrawidth` with `PowerlineDecoration`

--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -724,7 +724,8 @@ def inject_decorations(classdef):
             decoration.draw()
 
     def configure_decorations(self):
-        self.use_bar_background = False
+        if not hasattr(self, "use_bar_background"):
+            self.use_bar_background = False
         if hasattr(self, "decorations"):
             if not self.configured:
                 # Give each widget a copy of the decoration objects


### PR DESCRIPTION
When using `use_widget_background` the decoration does not draw correctly after a reload.