### PR TITLE
Fix `next_background` on `PowerLineDecoration`

### DIFF
--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -716,7 +716,7 @@ class PowerLineDecoration(_Decoration):
         if self.width == 0:
             return
 
-        self.set_next_colour()
+        self.next_background = self.override_next_colour or self.set_next_colour()
 
         self.ctx.save()
         self.draw_func()


### PR DESCRIPTION
I think you forgot this, it doesn't update the `next_background` color:
![image](https://user-images.githubusercontent.com/78786202/198157967-e6209116-cfd4-4dc0-a6af-f12970466b67.png)
