### PR TITLE
Fix mirror handling of decorations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-10: [BUGFIX] Better handling of decorations on mirrored widgets
 2022-11-10: [BUGFIX] Fix `Visualiser` segfault
 2022-11-08: [FEATURE] Add improvements to `StatusNotifier` menus
 2022-11-07: [FEATURE] Add ability to resize icons in `ALSAWidget` 


### PR DESCRIPTION
Mirrors need to draw decorations separately, particularly when using PowerLineDecorations as this looks at the next weidget in the bar for the colouring.

In order to do this, decorations cannot be drawn to the RecordingSurface otherwise mirrors will draw the same decoration. Instead, the decorations are now drawn directly to the window surface.

The PR also adds a new QTEMirror class as the Mirror draw method also needs to be updated as it looks at the parent's length but, as that may already have been modified by a decoration, we have to look at a different attribute.

Fixes #136