### PR TITLE
Convert `Visualiser` from shared memory to mmap

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-10: [BUGFIX] Fix `Visualiser` segfault
 2022-11-08: [FEATURE] Add improvements to `StatusNotifier` menus
 2022-11-07: [FEATURE] Add ability to resize icons in `ALSAWidget` 
 2022-11-06: [BUGFIX] `WiFiIcon` internet check handles other exceptions


### PR DESCRIPTION
Using SharedMemory seemed to result in a segfault when stopping, starting and reloading the widget.

Moving to mmap seems to fix the issue.

This should also fix the memory leak issue.

Fixes #135
Fixes #119