### PR TITLE
Fix underline length in `LiveFootballScores`

### DIFF
--- a/qtile_extras/widget/livefootballscores.py
+++ b/qtile_extras/widget/livefootballscores.py
@@ -445,7 +445,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin):
 
     def draw_underline(self, m):
         offset = 2
-        width = self.width - 2
+        width = self.calculate_length() - 2
 
         if m.is_fixture:
             fill = self.status_fixture


### PR DESCRIPTION
Underline extends to width of widget which includes any extra length from the decoration. This PR fixes that so the line is only drawn under the main widget body.