### PR TITLE
WiFi icon internet check fix

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-07: [BUGFIX] `WiFiIcon` internet check handles other exceptions
 2022-11-05: [BUGFIX] Hide `LiveFootballScores` widget when no match
 2022-11-01: [BUGFIX] Fix `StatusNotifier` menu bug where submenus do not appear
 2022-10-27: [BUGFIX] Fix Graph widgets to work with decorations

--- a/qtile_extras/widget/network.py
+++ b/qtile_extras/widget/network.py
@@ -139,7 +139,7 @@ class WiFiIcon(base._Widget, base.PaddingMixin):
             try:
                 s.connect((self.internet_check_host, self.internet_check_port))
                 return True
-            except TimeoutError:
+            except (TimeoutError, OSError):
                 return False
 
     def _check_connected(self, result):


### PR DESCRIPTION
The widget needs to handle more than `TimeoutError` as it can raise an `OSError` if there is no internet at all.