### PR TITLE
Fix recursion error with decoration injection

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-11: [BUGFIX] Fix infinite recursion error with decorated widget configuration
 2022-11-11: [BUGFIX] Fix `RectDecoration` clipping when widget is resized
 2022-11-11: [BUGFIX] Fix menu position for `StatusNotifier` and `GlobalMenu` widgets
 2022-11-10: [BUGFIX] Better handling of decorations on mirrored widgets


### PR DESCRIPTION
Where a widget inherits a class which has also had widget code injected then an infinite recursion loop can occur when the widget tries to _configure.

We can fix this by removing the injected code for subclasses while the widget is configured and then replace the injected code afterwards.

Fixes #163