### PR TITLE
Fix menu positions

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-11: [BUGFIX] Fix menu position for `StatusNotifier` and `GlobalMenu` widgets
 2022-11-10: [BUGFIX] Better handling of decorations on mirrored widgets
 2022-11-10: [BUGFIX] Fix `Visualiser` segfault
 2022-11-08: [FEATURE] Add improvements to `StatusNotifier` menus

--- a/qtile_extras/widget/globalmenu.py
+++ b/qtile_extras/widget/globalmenu.py
@@ -248,10 +248,6 @@ class GlobalMenu(base._TextBox):
             x = min(self.offsetx + self.item_pos, self.bar.width - self.menu.width)
             y = self.bar.screen.height - self.bar.height - self.menu.height
 
-        # Adjust the position by the screen's offset
-        x += self.bar.screen.x
-        y += self.bar.screen.y
-
         self.menu.show(x, y)
 
     def finalize(self):

--- a/qtile_extras/widget/statusnotifier.py
+++ b/qtile_extras/widget/statusnotifier.py
@@ -210,10 +210,6 @@ class StatusNotifier(QtileStatusNotifier):
             x = screen.width - self.bar.width - self.menu.width - 2 * self.menu_border_width
             y = min(self.offsety, screen.height - self.menu.height - 2 * self.menu_border_width)
 
-        # Adjust the position by the screen's offset
-        x += screen.x
-        y += screen.y
-
         # Adjust the position for any user-defined settings
         x += self.menu_offset_x
         y += self.menu_offset_y


### PR DESCRIPTION
d7367da5 passed the positioning of the popup to the toolkit. As such, the StatusNotifier and GlobalMenu widgets no longer need to adjust the position for the current screen.

Fixes #169