### PR TITLE
Fix LiveFootballScores indicator locations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-12: [BUGFIX] Fix away goal and red card indicator locations when using `PowerLineDecoration`
 2022-11-12: [BUGFIX] More fixes to decorations on mirrored widgets
 2022-11-12: [BUGFIX] More `RectDecoration` clipping fixes
 2022-11-12: [FEATURE] Add ability to set position of popup relative to corners, midpoints and centre of screen

--- a/qtile_extras/widget/livefootballscores.py
+++ b/qtile_extras/widget/livefootballscores.py
@@ -428,7 +428,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin):
         self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
 
     def draw_goal(self, home):
-        offset = 0 if home else (self.width - 2)
+        offset = 0 if home else (self.calculate_length() - 2)
 
         self.drawer.set_source_rgb(self.goal_indicator)
 
@@ -436,7 +436,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin):
         self.drawer.fillrect(offset, 0, 2, self.height, 2)
 
     def draw_red(self, home):
-        offset = 0 if home else (self.width - 2)
+        offset = 0 if home else (self.calculate_length() - 2)
 
         self.drawer.set_source_rgb(self.red_card_indicator)
 


### PR DESCRIPTION
Away indicators were in the wrong place when using the PowerLineDecoration as they were placed by reference to the widget's `width`.