### PR TITLE
Add ability to update popup controls

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-13: [FEATURE] Add ability to update popup control values
 2022-11-12: [BUGFIX] Fix menu bug in `GlobalMenu`
 2022-11-12: [FEATURE] `PopupImage` can display an alternative image as a highlight
 2022-11-12: [BUGFIX] Fix away goal and red card indicator locations when using `PowerLineDecoration`

--- a/docs/manual/how_to/popup.rst
+++ b/docs/manual/how_to/popup.rst
@@ -205,6 +205,47 @@ Pressing ``Mod+shift+g`` will present a popup window looking like this:
 
 .. image:: /_static/images/popupgraphs.png
 
+Updating controls
+=================
+
+There may be times when you wish to update the contents of the popup without
+having to rebuild the whole popup. This is possible by using the
+``popup.update_controls`` method. The method works by taking the name of the
+control (as set by the ``name`` parameter) as a keyword. Multiple controls can
+be updated in the same call.
+
+.. code:: python
+
+    text_popup = None
+
+    def create_text_popup(qtile):
+        global text_popup
+        text_popup = tk.PopupRelativeLayout(
+            qtile,
+            width=400,
+            height=200,
+            controls=[
+                tk.PopupText(
+                    text="Original Text",
+                    width=0.9,
+                    height=0.9,
+                    pos_x=0.05,
+                    pos_y=0.05,
+                    v_align="middle",
+                    h_align="center",
+                    fontsize=20,
+                    name="textbox1"
+                ),
+            ],
+            inital_focus=None,
+            close_on_click=False,
+        )
+
+        text_popup.show(centered=True)
+
+    def update_text_popup(qtile):
+        text_popup.update_controls(textbox1="Updated Text")
+
 Extending widgets
 =================
 

--- a/test/popup/test_toolkit.py
+++ b/test/popup/test_toolkit.py
@@ -531,3 +531,54 @@ def test_popup_positioning_centered(manager):
     info = eval(info)
 
     assert (info["x"], info["y"]) == (300, 200)
+
+
+def test_popup_update_controls(manager):
+    layout = textwrap.dedent(
+        """
+        from libqtile import widget
+        from qtile_extras.popup.toolkit import (
+            PopupRelativeLayout,
+            PopupText,
+            PopupSlider
+        )
+        self.popup = PopupRelativeLayout(
+            self,
+            controls=[
+                PopupText(
+                    text="Original Text",
+                    pos_x=0.1,
+                    pos_y=0.1,
+                    width=0.4,
+                    height=0.8,
+                    horizontal=False,
+                    name="textbox1"
+                ),
+                PopupSlider(
+                    pos_x=0.5,
+                    pos_y=0.1,
+                    width=0.4,
+                    height=0.8,
+                    value=0.5,
+                    name="slider1"
+                ),
+            ],
+            margin=0
+        )
+
+        self.popup.show()
+        """
+    )
+
+    manager.c.eval(layout)
+    _, info = manager.c.eval("self.popup.info()")
+    info = eval(info)
+    assert info["controls"][0]["text"] == "Original Text"
+    assert info["controls"][1]["value"] == 0.5
+
+    # Update controls
+    _, out = manager.c.eval("self.popup.update_controls(textbox1='New Text', slider1=0.8)")
+    _, info = manager.c.eval("self.popup.info()")
+    info = eval(info)
+    assert info["controls"][0]["text"] == "New Text"
+    assert info["controls"][1]["value"] == 0.8


### PR DESCRIPTION
Adds a new `popup.update_controls` method which allows control values to be updated without having to recreate the whole popup.

Fixes #165