### PR TITLE
Fix `RectDecoration` when not filled

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2022-11-22: [FEATURE] Add ability to draw border in different colour in `RectDecoration`
+2022-11-22: [BUGFIX] Fix `RectDecoration` grouping when not filled
 2022-11-18: [FEATURE] Add support for web-based images in `PopupImage` and `Image` widget
 2022-11-18: [FEATURE] Add ability to draw border on `PopupSlider` controls
 2022-11-18: [FEATURE] Add `ExtendedPopupMixin` to simplify adding popups to widgets

--- a/test/widget/test_widget_decorations.py
+++ b/test/widget/test_widget_decorations.py
@@ -81,12 +81,16 @@ def test_rect_decoration_using_widget_background(manager_nospawn, minimal_conf_n
                     widget.ScriptExit(
                         name="one",
                         background="ff0000",
-                        decorations=[RectDecoration(colour="00ff00")],
+                        decorations=[RectDecoration(colour="00ff00", filled=True)],
                     ),
                     widget.ScriptExit(
                         name="two",
                         background="ff0000",
-                        decorations=[RectDecoration(colour="00ff00", use_widget_background=True)],
+                        decorations=[
+                            RectDecoration(
+                                colour="00ff00", use_widget_background=True, filled=True
+                            )
+                        ],
                     ),
                 ],
                 10,


### PR DESCRIPTION
The decoration drew lines between grouped widgets. This PR should remove those middle lines.

Fixes #195
Fixes #193