### PR TITLE
Fix decoration configure inside WidgetBox

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-11-24: [BUGFIX] Fix bug where decoration crashes on widget initialised inside a `WidgetBox`
 2022-11-23: [FEATURE] Add extended popups to `ALSAWidget` and `BrightnessControl` (experimental)
 2022-11-22: [FEATURE] Add ability to draw border in different colour in `RectDecoration`
 2022-11-22: [BUGFIX] Fix `RectDecoration` grouping when not filled

--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -642,17 +642,16 @@ class PowerLineDecoration(_Decoration):
         self.next_background = self.override_next_colour or self.set_next_colour()
 
     def set_next_colour(self):
-        index = self.parent.bar.widgets.index(self.parent)
-        widgets = self.parent.bar.widgets
-
         try:
+            index = self.parent.bar.widgets.index(self.parent)
+            widgets = self.parent.bar.widgets
             next_widget = next(
                 w
                 for w in widgets
                 if hasattr(w, "length") and w.length and widgets.index(w) > index
             )
             return next_widget.background or self.parent.bar.background
-        except (IndexError, StopIteration):
+        except (ValueError, IndexError, StopIteration):
             return self.parent.bar.background
 
     def paint_background(self, background):


### PR DESCRIPTION
A widget inside a widgetbox is not added to the list of bar widgets and so the PowerLine decoration cannot find the next widget in the bar as its parent is not in the bar.