### PR TITLE
Fix and improve `AnalogueClock`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-12-01: [FEATURE] Add ability to fine tune position of `AnalogueClock`
 2022-11-29: [BUGFIX] Handle JSON error in `TVHWidget`
 2022-11-26: [FEATURE] Add extended popup to `LiveFootballScores`
 2022-11-24: [BUGFIX] Fix bug where decoration crashes on widget initialised inside a `WidgetBox`


### PR DESCRIPTION
`AnalogueClock` had a little bug in it which should now be fixed (failed to initialise a variable correctly).

Added ability to fine tune position of clock via new `adjust_x/y` parameters.

Fixes #206