### PR TITLE
Fix popup redraw bug after mouse focus change

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-12-21: [BUGFIX] Fix issue redrawing controls after mouse focus change
 2022-12-20: [FEATURE] Add `ProgressBarMixin` and convert `ALSAWidget` and `BrightnessControl` to use mixin
 2022-12-19: [BUGFIX] Update `StravaWidget` to `stravalib v1.1.0` (NB new dependency `pint`)
 2022-12-03: [FEATURE] Add extended popup to `Mpris2`

--- a/qtile_extras/popup/toolkit.py
+++ b/qtile_extras/popup/toolkit.py
@@ -948,13 +948,13 @@ class _PopupWidget(configurable.Configurable):
         if self.can_focus and self.highlight and not self._highlight:
             self.focus()
             self.draw()
-            self.container.popup.draw()
+            self.container.draw()
 
     def mouse_leave(self, x, y):
         if self.can_focus and self._highlight:
             self.unfocus()
             self.draw()
-            self.container.popup.draw()
+            self.container.draw()
 
     def info(self):
         return {


### PR DESCRIPTION
Popups were not rendering correctly after a mouse focus change leading to artefacts where the popup background was not cleared.

Fixes #217