### PR TITLE
Fix livefootballscores separator bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2022-12-31: [BUGFIX] Fix bug in `LiveFootballScores` info popup with excess separators
 2022-12-26: [FEATURE] Add decoration grouping to BorderDecorations
 2022-12-25: [BUGFIX] Catch errors where `SnapCast` widget can't retrieve ID from server
 2022-12-22: [FEATURE] Add `Syncthing` widget

--- a/qtile_extras/widget/livefootballscores.py
+++ b/qtile_extras/widget/livefootballscores.py
@@ -590,9 +590,9 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
     def info(self):
         """Show information about all matches"""
         str_team = self.team
-        str_teams = ",".join(self.teams)
-        str_leagues = ",".join(self.leagues)
-        obj_team = ",".join([str(team) for team in self.sources[0]])
+        str_teams = ", ".join(self.teams)
+        str_leagues = ", ".join(self.leagues)
+        obj_team = ", ".join([str(team) for team in self.sources[0]])
 
         obj_teams = {}
         for team in self.sources[1]:
@@ -677,7 +677,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
             )
 
         if self.sources[1]:
-            if lines:
+            if lines and any(m for m in self.sources[1]):
                 lines.append(PopupMenuSeparator())
 
             lines.append(PopupMenuItem(text="Selected Teams:", enabled=False))
@@ -688,7 +688,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
                 )
 
         for league in self.sources[2]:
-            if lines:
+            if lines and league:
                 lines.append(PopupMenuSeparator())
             if league:
                 lines.append(PopupMenuItem(text="{}:".format(league.league_name), enabled=False))

--- a/test/widget/resources/lfs_data.py
+++ b/test/widget/resources/lfs_data.py
@@ -881,3 +881,6 @@ PREMIER_LEAGUE = {
         }
     ],
 }
+
+
+NO_MATCHES = {"fixtureListMeta": {"scorersButtonShouldBeEnabled": True}, "matchData": []}

--- a/test/widget/test_livefootballscores.py
+++ b/test/widget/test_livefootballscores.py
@@ -68,8 +68,11 @@ class MatchRequest:
             return lfs_data.CHELSEA
         elif "liverpool" in self.url:
             return lfs_data.LIVERPOOL
-        else:
+        # Ugly hack to get the premier league data when no tournament provided!
+        elif "premier-league" in self.url or "tournament/full-priority" in self.url:
             return lfs_data.PREMIER_LEAGUE
+        else:
+            return lfs_data.NO_MATCHES
 
 
 @pytest.fixture(scope="function")
@@ -115,8 +118,8 @@ def lfs_manager(lfswidget):
                     [
                         lfswidget.LiveFootballScores(
                             team="Chelsea",
-                            teams=["Liverpool"],
-                            leagues=["premier-league"],
+                            teams=["Liverpool", "Real Madrid"],
+                            leagues=["premier-league", "FIFA World Cup"],
                             startup_delay=0,
                             info_timeout=0.3,
                         )
@@ -217,12 +220,20 @@ def test_widget_info(lfs_manager, manager_nospawn):
                     4: "Watford 0-0 Manchester United (15:00)",
                     5: "Wolverhampton Wanderers 0-0 West Ham United (15:00)",
                     6: "Liverpool 0-0 Arsenal (17:30)",
-                }
+                },
+                "FIFA World Cup": {},
             },
             "team": "Chelsea 1-1 Burnley (FT)",
-            "teams": {"Liverpool": "West Ham United 3-2 Liverpool (FT)"},
+            "teams": {
+                "Liverpool": "West Ham United 3-2 Liverpool (FT)",
+                "Real Madrid": "Real Madrid are not playing today.",
+            },
         },
-        "sources": {"leagues": "premier-league", "team": "Chelsea", "teams": "Liverpool"},
+        "sources": {
+            "leagues": "premier-league, FIFA World Cup",
+            "team": "Chelsea",
+            "teams": "Liverpool, Real Madrid",
+        },
     }
 
 


### PR DESCRIPTION
Widget has a bug where the summary popup had excess separators whenever there were `teams` or `leagues` that had no current matches.

This PR limits the occasions when the separator is included in the popup.