### PR TITLE
Fix decoration issue with `Notify` widget

### DIFF
--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -816,7 +816,7 @@ def inject_decorations(classdef):
         """Draw decorations after clearing background."""
         if self.use_bar_background:
             colour = self.bar.background
-        self._clear(colour)
+        self.__clear(colour)
 
         for decoration in self.decorations:
             decoration.draw()
@@ -838,7 +838,7 @@ def inject_decorations(classdef):
             for dec in self.decorations:
                 dec._configure(self)
 
-            self._clear = self.drawer.clear
+            self.__clear = self.drawer.clear
             self.drawer.clear = self.new_clear
 
     def new_configure(self, qtile, bar):


### PR DESCRIPTION
Qtile's `Notify` widget currently has a `_clear` method which is the same name as a method injected by the decoration code. As a result, the `Notify` widget does not render correctly when imported via qtile-extras. We can fix that by renaming the injected method.

Fixes #233