### PR TITLE
Update StatusNotifier to fix bug in electron apps

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2023-04-09: [BUGFIX] Fix menus in `StatusNotifier` for updated electron apps
 2023-01-13: [FEATURE] Add support for local icons in `StatusNotifier` context menus
 2023-01-03: [FEATURE] Add `PopupCircularProgress` control to popup toolkit
 2022-12-31: [BUGFIX] Fix bug in `LiveFootballScores` info popup with excess separators

--- a/qtile_extras/resources/dbusmenu/dbusmenu.py
+++ b/qtile_extras/resources/dbusmenu/dbusmenu.py
@@ -1,0 +1,60 @@
+DBUS_MENU_SPEC = """
+<!DOCTYPE node PUBLIC "-//freedesktop//DTD D-BUS Object Introspection 1.0//EN"
+"http://www.freedesktop.org/standards/dbus/1.0/introspect.dtd">
+<node>
+<interface name="com.canonical.dbusmenu">
+    <property name="Version" type="u" access="read" />
+    <property name="TextDirection" type="s" access="read" />
+    <property name="Status" type="s" access="read" />
+    <property name="IconThemePath" type="as" access="read" />
+    <method name="GetLayout">
+        <arg type="i" name="parentId" direction="in" />
+        <arg type="i" name="recursionDepth" direction="in" />
+        <arg type="as" name="propertyNames" direction="in" />
+        <arg type="u" name="revision" direction="out" />
+        <arg type="(ia{sv}av)" name="layout" direction="out" />
+    </method>
+    <method name="GetGroupProperties">
+        <arg type="ai" name="ids" direction="in" />
+        <arg type="as" name="propertyNames" direction="in" />
+        <arg type="a(ia{sv})" name="properties" direction="out" />
+    </method>
+    <method name="GetProperty">
+        <arg type="i" name="id" direction="in" />
+        <arg type="s" name="name" direction="in" />
+        <arg type="v" name="value" direction="out" />
+    </method>
+    <method name="Event">
+        <arg type="i" name="id" direction="in" />
+        <arg type="s" name="eventId" direction="in" />
+        <arg type="v" name="data" direction="in" />
+        <arg type="u" name="timestamp" direction="in" />
+    </method>
+    <method name="EventGroup">
+        <arg type="a(isvu)" name="events" direction="in" />
+        <arg type="ai" name="idErrors" direction="out" />
+    </method>
+    <method name="AboutToShow">
+        <arg type="i" name="id" direction="in" />
+        <arg type="b" name="needUpdate" direction="out" />
+    </method>
+    <method name="AboutToShowGroup">
+        <arg type="ai" name="ids" direction="in" />
+        <arg type="ai" name="updatesNeeded" direction="out" />
+        <arg type="ai" name="idErrors" direction="out" />
+    </method>
+    <signal name="ItemsPropertiesUpdated">
+        <arg type="a(ia{sv})" name="updatedProps" direction="out" />
+        <arg type="a(ias)" name="removedProps" direction="out" />
+    </signal>
+    <signal name="LayoutUpdated">
+        <arg type="u" name="revision" direction="out" />
+        <arg type="i" name="parent" direction="out" />
+    </signal>
+    <signal name="ItemActivationRequested">
+        <arg type="i" name="id" direction="out" />
+        <arg type="u" name="timestamp" direction="out" />
+    </signal>
+</interface>
+</node>
+"""

--- a/test/widget/test_statusnotifier.py
+++ b/test/widget/test_statusnotifier.py
@@ -174,6 +174,9 @@ async def test_statusnotifier_dbusmenu_errors(monkeypatch, caplog):
                 async def introspect(self, *args, **kwargs):
                     raise MockBus.error
 
+                def get_proxy_object(self, service, path, introspection):
+                    raise MockBus.error
+
             return Bus()
 
     monkeypatch.setattr("qtile_extras.resources.dbusmenu.MessageBus", MockBus)
@@ -186,9 +189,14 @@ async def test_statusnotifier_dbusmenu_errors(monkeypatch, caplog):
     assert caplog.record_tuples == [
         (
             "libqtile",
+            logging.INFO,
+            "Cannot find com.canonical.dbusmenu interface at test.qtile_extras.menu. Falling back to default spec.",
+        ),
+        (
+            "libqtile",
             logging.WARNING,
-            "Cannot find com.canonical.dbusmenu interface at test.qtile_extras.menu",
-        )
+            "Could not find com.canonical.dbusmenu interface at test.qtile_extras.menu and unable to use default spec.",
+        ),
     ]
 
     caplog.clear()


### PR DESCRIPTION
Electron apps are no longer using libappindicator to generate StatusNotifierItem icons. This change has resulted in items not being open to introspection which means we need to rely on a default interface specification.

Requires https://github.com/qtile/qtile/pull/4226