### PR TITLE
Fix attribute error in decorations

### DIFF
--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -641,6 +641,10 @@ class PowerLineDecoration(_Decoration):
         self.shift = max(min(self.shift, self.size), 0)
         self._extrawidth += self.size - self.shift
 
+        # This decoration doesn't use the GroupMixin but we need to set the property
+        # as False as it's used in a couple of checks when other decorations are grouped
+        self.group = False
+
     @property
     def parent_length(self):
         if self.parent.length_type == bar.CALCULATED:


### PR DESCRIPTION
Fixes a bug where a widget has multiple decorations, one of which is grouped and another which is a `PowerLineDecoration`. The bug arises because the `PowerLineDecoration` does not inherit the `GroupMixin` and, as a result, does not set the `group` attribute. However, when grouped widgets checking grouping, they loop over all decorations and check the `group` attribute. This therefore fails when the loop hits the `PowerLineDecoration`.

This PR fixes the issue by hardcoding the `group` attribute for `PowerLineDecoration` objects.

Fixes #248