### PR TITLE
Fix RectDecoration clash with ImgMask

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2023-09-01: [BUGFIX] Fix two `RectDecoration` rendering bugs (issues #266 and #267)
 2023-08-13: [BUGFIX] Fix `PowerLineDecoration` for Wayland (and make it generally better)
 2023-08-10: [BUGFIX] X11 - fix issue with translucent decorations resulting in artefacts (needs latest qtile).
 2023-08-06: [BREAKING CHANGE] Update imports to align with qtile codebase tidy. You need latest qtile git version.

--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -293,7 +293,7 @@ class RectDecoration(_Decoration, GroupMixin):
         self.corners = self.single_or_four(self.radius, "Corner radius")
 
     def _draw_path(self, clip=False):
-        ctx = self.ctx if not clip else self.drawer.ctx
+        ctx = self.ctx
         ctx.new_path()
 
         # If we're clipping then we want the path to be inside
@@ -420,7 +420,12 @@ class RectDecoration(_Decoration, GroupMixin):
         # area defined by the decoration
         if self.clip:
             self._draw_path(clip=True)
-            self.drawer.ctx.clip()
+            self.ctx.clip()
+        # If we're not clipping then we need to clear any existing paths
+        # (fill_preserve, above, retains the path) to ensure no undesired effects
+        # for contents being rendered by widgets, e.g. using masks.
+        else:
+            self.ctx.new_path()
 
 
 class BorderDecoration(_Decoration, GroupMixin):


### PR DESCRIPTION
1) `RectDecoration` could, in certain situations, cause an issue with  widgets using the `Img` masking behaviour, resulting in just a filled decoration.
2) `RectDecoration` had an issue with the `GroupBox` widget where a border could be drawn when just one group showed.

Fixes https://github.com/elParaguayo/qtile-extras/issues/266
Fixes https://github.com/elParaguayo/qtile-extras/issues/267