### PR TITLE
Add support for GlobalMenu for wayland

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2023-09-18: [FEATURE] Add experimental support for `GlobalMenu` in Wayland.
 2023-09-17: [TESTS] Check decorations are rendered correctly during test suite
 2023-09-16: [FEATURE] Add more popup templates for `Mpris2` widget
 2023-09-16: [FEATURE] Add `PulseVolumeExtra` widget

--- a/test/widget/test_global_menu.py
+++ b/test/widget/test_global_menu.py
@@ -62,9 +62,6 @@ gmconfig = pytest.mark.parametrize("manager", [GlobalMenuConfig], indirect=True)
 @pytest.mark.usefixtures("dbus")
 def test_global_menu(manager, backend_name):
     """Check widget displays text, opens menu and triggers events."""
-    if backend_name == "wayland":
-        pytest.skip("Can't get window ID on Wayland.")
-
     # Widget has 0 width when no window open
     assert manager.c.widget["globalmenu"].info()["width"] == 0
     assert len(manager.c.windows()) == 0

--- a/tox.ini
+++ b/tox.ini
@@ -40,7 +40,7 @@ deps =
 # pywayland has to be installed before pywlroots
 commands =
     pip install --force-reinstall --no-binary :all: cffi
-    pip install pywlroots>=0.16.4,<0.17.0
+    pip install pywlroots==0.16.4
     pip install xcffib>=1.4.0 wheel
     pip install cairocffi>=1.6.0
     pip install git+https://github.com/elParaguayo/qtile.git@fixing-packaging
@@ -115,7 +115,7 @@ deps =
     stravalib <= 1.1.0
 commands =
     pip install --force-reinstall --no-binary :all: cffi
-    pip install pywlroots>=0.16.4,<0.17.0
+    pip install pywlroots==0.16.4
     pip install xcffib>=1.4.0 wheel
     pip install cairocffi>=1.6.0
     pip install git+https://github.com/elParaguayo/qtile.git@fixing-packaging


### PR DESCRIPTION
This is experimental!

Wayland windows don't have an ID so we can try using the process ID to match windows to their dbus service.