### PR TITLE
Add ability to invert visualiser

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2023-11-13: [FEATURE] Add `invert` option to `Visualiser` to draw bars from top down
 2023-11-12: [BUGFIX] (Trying to) fix increasing CPU with `Visualiser` widget
 2023-11-11: [DOCS] Update installation instructions
 2023-11-10: [FEATURE] Add custom hooks to certain widgets (refer to docs for more)

--- a/qtile_extras/widget/visualiser.py
+++ b/qtile_extras/widget/visualiser.py
@@ -88,6 +88,7 @@ class Visualiser(base._Widget):
         ("autostart", True, "Start visualiser automatically"),
         ("hide", True, "Hide the visualiser when not active"),
         ("channels", "mono", "Visual channels. 'mono' or 'stereo'."),
+        ("invert", False, "When True, bars will draw from the top down"),
     ]
 
     _screenshots = [("visualiser.gif", "Default config.")]
@@ -143,24 +144,26 @@ class Visualiser(base._Widget):
     def _start(self):
         self._starting = True
         self.cava_proc = self.qtile.spawn([self.cava_path, "-p", self.config_file.name])
-        self.draw_proc = self.qtile.spawn(
-            [
-                PYTHON,
-                CAVA_DRAW.resolve().as_posix(),
-                "--width",
-                f"{self._config_length}",
-                "--height",
-                f"{self.bar_height}",
-                "--bars",
-                f"{self.bars}",
-                "--spacing",
-                f"{self.spacing}",
-                "--pipe",
-                f"{self.cava_pipe}",
-                "--background",
-                self.bar_colour,
-            ]
-        )
+        cmd = [
+            PYTHON,
+            CAVA_DRAW.resolve().as_posix(),
+            "--width",
+            f"{self._config_length}",
+            "--height",
+            f"{self.bar_height}",
+            "--bars",
+            f"{self.bars}",
+            "--spacing",
+            f"{self.spacing}",
+            "--pipe",
+            f"{self.cava_pipe}",
+            "--background",
+            self.bar_colour,
+        ]
+        if self.invert:
+            cmd.append("--invert")
+
+        self.draw_proc = self.qtile.spawn(cmd)
         self._timer = self.timeout_add(1, self._open_shm)
 
     def _stop(self):


### PR DESCRIPTION
Adds `invert` parameter to the `Visualiser` widget which allows the bars to be drawn from the top of the widget.

The commit also simplifies the drawing of the bars.