### PR TITLE
Fix `fraction` KeyError in `UpowerWidget`

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2023-11-13: [BUGFIX] Fix `fraction` KeyError in `UpowerWidget`
 2023-11-13: [FEATURE] Add `invert` option to `Visualiser` to draw bars from top down
 2023-11-12: [BUGFIX] (Trying to) fix increasing CPU with `Visualiser` widget
 2023-11-11: [DOCS] Update installation instructions

--- a/qtile_extras/widget/upower.py
+++ b/qtile_extras/widget/upower.py
@@ -229,6 +229,7 @@ class UPowerWidget(base._Widget):
             bat["props"] = props
             bat["name"] = await battery_dev.get_native_path()
             bat["flags"] = BatteryState.NONE
+            bat["fraction"] = 0.5
 
             battery_devices.append(bat)
 


### PR DESCRIPTION
To draw the widget, the code looks up the `fraction` key in the battery's dictionary. However, if draw has been called before this information has been retrieved (as can happen at startup), a KeyError arises.

This PR fixes the issue by initialising the battery with a default value of 50%.