### PR TITLE
Add python 3.12 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
         name: "python ${{ matrix.python-version }}"
         strategy:
             matrix:
-                python-version: [3.9, '3.10', '3.11']
+                python-version: [3.9, '3.10', '3.11', '3.12']
         steps:
             - uses: actions/checkout@v2
             - name: Set up python ${{ matrix.python-version }}

--- a/tox.ini
+++ b/tox.ini
@@ -4,6 +4,7 @@ envlist =
     py39,
     py310,
     py311,
+    py312,
     packaging
 isolated_build = True
 
@@ -96,3 +97,4 @@ python =
     3.9: py39
     3.10: py310
     3.11: py311, packaging
+    3.12: py312


### PR DESCRIPTION
Keep 3.11 as "main" test for now (e.g. decoration rendering).