### PR TITLE
Updated documentation - Added missing newline which prevented code block from showing.

### DIFF
--- a/docs/manual/how_to/popup.rst
+++ b/docs/manual/how_to/popup.rst
@@ -215,6 +215,7 @@ control (as set by the ``name`` parameter) as a keyword. Multiple controls can
 be updated in the same call.
 
 .. code:: python
+
     from qtile_extras.popup.toolkit import (
         PopupRelativeLayout,
         PopupText


### PR DESCRIPTION
I'm really sorry, my last PR broke the code block!
Sometimes newlines are important :sweat_smile: 
I didn't even think to view it, since it looked like such a simple update. Lesson learnt, code always breaks lol.

The code block for the section "Updating Controls" doesn't show.
[https://github.com/elParaguayo/qtile-extras/blob/main/docs/manual/how_to/popup.rst#updating-controls](https://github.com/elParaguayo/qtile-extras/blob/main/docs/manual/how_to/popup.rst#updating-controls)

And now it does show.
[https://github.com/sslater11/qtile-extras/blob/documentation/docs/manual/how_to/popup.rst#updating-controls](https://github.com/sslater11/qtile-extras/blob/documentation/docs/manual/how_to/popup.rst#updating-controls)
