### PR TITLE
Fix bug Visualiser doesn't start when unhidden

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-01-20: [BUGFIX] Fix `Visualiser` bug with `hide=True`
 2024-01-20: [FEATURE] Add `GroupBox2` widget
 2023-12-21: [FEATURE] Add `IWD` widget
 2023-11-17: [BUGFIX] Prevent double hooks for Mpris2 widget

--- a/qtile_extras/widget/visualiser.py
+++ b/qtile_extras/widget/visualiser.py
@@ -139,7 +139,7 @@ class Visualiser(base._Widget):
         else:
             new = 0
 
-        if old != new:
+        if old != new or not self.hide:
             self.bar.draw()
 
         self.length = new


### PR DESCRIPTION
Setting `hide=False` to the Visualiser prevents the visualiser drawing correctly until the entire bar is redrawn. We fix this by forcing a bar redraw once the cava process has started.