### PR TITLE
Fix Volume bug where volume > 100

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-03-02: [BUGFIX] Fix bug for volume widgets where bar crashes if volume is greater than 100%
 2024-03-02: [BUGFIX] Fix popup menus ignoring config
 2024-02-17: [FEATURE] Add `AnimatedImage` widget
 2024-02-16: [FEATURE] Allow pango markup in `PopupText` controls

--- a/qtile_extras/widget/base.py
+++ b/qtile_extras/widget/base.py
@@ -276,7 +276,10 @@ class _Volume(base._Widget, ExtendedPopupMixin, ProgressBarMixin):
             # Text and colour depends on mute status and volume level
             if not self.muted:
                 bar_text = self.text_format.format(volume=self.volume)
-                bar_colour = next(x[1] for x in self.colours if self.volume <= x[0])
+                bar_colour = next(
+                    (x[1] for x in self.colours if self.volume <= x[0]),
+                    self.colours[-1][1],  # Default if volume > 100%
+                )
             else:
                 bar_text = "X"
                 bar_colour = self.bar_colour_mute


### PR DESCRIPTION
The bar colour selector expects a volume level <= 100. Some devices allow values > 100 so we need to catch this scenario.

Fixes #302