### PR TITLE
Add ability to customise position of widget menus

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-03-10: [FEATURE] Expose widget popup menu commands and allow custom positioning
 2024-03-02: [BUGFIX] Fix bug for volume widgets where bar crashes if volume is greater than 100%
 2024-03-02: [BUGFIX] Fix popup menus ignoring config
 2024-02-17: [FEATURE] Add `AnimatedImage` widget

--- a/qtile_extras/widget/bluetooth.py
+++ b/qtile_extras/widget/bluetooth.py
@@ -41,8 +41,29 @@ class Bluetooth(QBluetooth, MenuMixin):
         self.add_callbacks({"Button3": self.show_devices})
 
     @expose_command
-    def show_devices(self):
+    def show_devices(
+        self,
+        x=None,
+        y=None,
+        centered=False,
+        warp_pointer=False,
+        relative_to=1,
+        relative_to_bar=False,
+        hide_on_timeout=None,
+    ):
         """Show menu with available adapters and devices."""
+        self.display_menu(
+            menu_items=self._get_menu_items(),
+            x=x,
+            y=y,
+            centered=centered,
+            warp_pointer=warp_pointer,
+            relative_to=relative_to,
+            relative_to_bar=relative_to_bar,
+            hide_on_timeout=hide_on_timeout,
+        )
+
+    def _get_menu_items(self):
         menu_items = []
 
         pmi = self.create_menu_item
@@ -79,4 +100,4 @@ class Bluetooth(QBluetooth, MenuMixin):
             for device in devices:
                 menu_items.append(pmi(device.name, **action(device)))
 
-        self.display_menu(menu_items=menu_items)
+        return menu_items

--- a/qtile_extras/widget/iwd.py
+++ b/qtile_extras/widget/iwd.py
@@ -306,7 +306,7 @@ class IWD(base._TextBox, base.MarginMixin, MenuMixin, GraphicalWifiMixin, Connec
         self._network_tasks = []
         self.timer = None
         self._setting_up = False
-        self.add_callbacks({"Button1": self.do_menu})
+        self.add_callbacks({"Button1": self.show_networks})
         self._can_connect = False
         self.percentage = 0
         self._refresh_timer = None
@@ -566,7 +566,7 @@ class IWD(base._TextBox, base.MarginMixin, MenuMixin, GraphicalWifiMixin, Connec
             offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
         )
 
-    def do_menu(self):
+    def _get_menu_items(self):
         menu_items = []
         pmi = self.create_menu_item
         pms = self.create_menu_separator
@@ -621,7 +621,7 @@ class IWD(base._TextBox, base.MarginMixin, MenuMixin, GraphicalWifiMixin, Connec
 
         menu_items.append(device_item)
 
-        self.display_menu(menu_items)
+        return menu_items
 
     def connect_response(self, task):
         exc = task.exception()
@@ -630,6 +630,29 @@ class IWD(base._TextBox, base.MarginMixin, MenuMixin, GraphicalWifiMixin, Connec
                 logger.info("Password entry cancelled.")
             else:
                 logger.warning("Could not connect: %s", exc)
+
+    @expose_command
+    def show_networks(
+        self,
+        x=None,
+        y=None,
+        centered=False,
+        warp_pointer=False,
+        relative_to=1,
+        relative_to_bar=False,
+        hide_on_timeout=None,
+    ):
+        """Show menu with available networks."""
+        self.display_menu(
+            menu_items=self._get_menu_items(),
+            x=x,
+            y=y,
+            centered=centered,
+            warp_pointer=warp_pointer,
+            relative_to=relative_to,
+            relative_to_bar=relative_to_bar,
+            hide_on_timeout=hide_on_timeout,
+        )
 
     @expose_command
     def scan(self):

--- a/qtile_extras/widget/livefootballscores.py
+++ b/qtile_extras/widget/livefootballscores.py
@@ -271,7 +271,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
         self.add_callbacks(
             {
                 "Button1": self.loop_match_info,
-                "Button3": self.show_menu,
+                "Button3": self.show_matches,
                 "Button4": self.scroll_up,
                 "Button5": self.scroll_down,
             }
@@ -625,7 +625,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
         if self.menu and not self.menu._killed:
             self.menu.kill()
         else:
-            self.show_menu()
+            self.show_matches()
 
     @expose_command()
     def popup(self):
@@ -703,5 +703,25 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
 
         return lines
 
-    def show_menu(self):
-        self.display_menu(self._get_match_list())
+    @expose_command
+    def show_matches(
+        self,
+        x=None,
+        y=None,
+        centered=False,
+        warp_pointer=False,
+        relative_to=1,
+        relative_to_bar=False,
+        hide_on_timeout=None,
+    ):
+        """Show menu with followed matchs."""
+        self.display_menu(
+            menu_items=self._get_match_list(),
+            x=x,
+            y=y,
+            centered=centered,
+            warp_pointer=warp_pointer,
+            relative_to=relative_to,
+            relative_to_bar=relative_to_bar,
+            hide_on_timeout=hide_on_timeout,
+        )

--- a/qtile_extras/widget/pulse_volume.py
+++ b/qtile_extras/widget/pulse_volume.py
@@ -48,7 +48,16 @@ class PulseVolume(QPulseVolume, MenuMixin):
 
         await pulse.pulse.default_set(sink)
 
-    async def show_sinks(self):
+    async def show_sinks(
+        self,
+        x=None,
+        y=None,
+        centered=False,
+        warp_pointer=False,
+        relative_to=1,
+        relative_to_bar=False,
+        hide_on_timeout=None,
+    ):
         if not pulse.pulse.connected:
             return
 
@@ -68,9 +77,36 @@ class PulseVolume(QPulseVolume, MenuMixin):
         for sink in sinks:
             menu_items.append(pmi(text=sink.description, **_callback(sink)))
 
-        self.display_menu(menu_items)
+        self.display_menu(
+            menu_items,
+            x=x,
+            y=y,
+            centered=centered,
+            warp_pointer=warp_pointer,
+            relative_to=relative_to,
+            relative_to_bar=relative_to_bar,
+            hide_on_timeout=hide_on_timeout,
+        )
 
     @expose_command()
-    def select_sink(self):
+    def select_sink(
+        self,
+        x=None,
+        y=None,
+        centered=False,
+        warp_pointer=False,
+        relative_to=1,
+        relative_to_bar=False,
+        hide_on_timeout=None,
+    ):
         """Select output sink from available sinks."""
-        create_task(self.show_sinks())
+        task = self.show_sinks(
+            x=x,
+            y=y,
+            centered=centered,
+            warp_pointer=warp_pointer,
+            relative_to=relative_to,
+            relative_to_bar=relative_to_bar,
+            hide_on_timeout=hide_on_timeout,
+        )
+        create_task(task)


### PR DESCRIPTION
The popup toolkit has some powerful funcitonality for customising the location of the popup. This PR exposes those methods to exposed commands for widgets using the popup menu. Clicking on widgets retains the default behaviour (menu appears by the widget) but it's also possible to call the command with specific arguments (e.g. binding a key to open IWD's network list in the middle of the screen).