### PR TITLE
Fix border bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-05-29: [BUGFIX] Fix bug with border decorations when using both standard and decorated borders
 2024-05-22: [RELEASE] v0.26.0 release - compatible with qtile 0.26.0
 2024-05-19: [FEATURE] Add modified `Plasma` layout to include border highlighting
 2024-05-10: [FEATURE] Add window border decorations (NB experimental)

--- a/qtile_extras/layout/decorations/injections.py
+++ b/qtile_extras/layout/decorations/injections.py
@@ -112,11 +112,18 @@ def wayland_paint_borders(self, colors: ColorsType | None, width: int) -> None:
             if old_borders:
                 rects = old_borders.pop(0)
                 for (x, y, w, h), rect in zip(geometries, rects):
-                    rect.set_color(color_)
-                    rect.set_size(w, h)
-                    rect.node.set_position(x, y)
-
+                    if isinstance(rect, SceneRect):
+                        rect.set_color(color_)
+                        rect.set_size(w, h)
+                        rect.node.set_position(x, y)
+                        needs_new_rects = False
+                    else:
+                        rect.node.destroy()
+                        needs_new_rects = True
             else:
+                needs_new_rects = True
+
+            if needs_new_rects:
                 rects = []
                 for x, y, w, h in geometries:
                     rect = SceneRect(self.container, w, h, color_)


### PR DESCRIPTION
When using a mix of decorated and standard borders, we need to check the type of border before trying to reuse SceneRect objects.