### PR TITLE
Fix GlobalMenu callback bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-06-01: [BUGFIX] Fix `GlobalMenu` crash after reloading config
 2024-05-29: [BUGFIX] Fix bug with border decorations when using both standard and decorated borders
 2024-05-22: [RELEASE] v0.26.0 release - compatible with qtile 0.26.0
 2024-05-19: [FEATURE] Add modified `Plasma` layout to include border highlighting

--- a/test/widget/test_global_menu.py
+++ b/test/widget/test_global_menu.py
@@ -71,9 +71,7 @@ def test_global_menu(manager, backend_name):
     wait_for_internal(manager, 2)
     window = [x for x in manager.c.internal_windows() if x.get("name", "") == "dbuspopup"][0]
     assert window
-    manager.c.widget["globalmenu"].eval(
-        f"asyncio.create_task(self.get_window_menu({window['id']}))"
-    )
+    manager.c.widget["globalmenu"].eval(f"create_task(self.get_window_menu({window['id']}))")
     wait_for_text(manager, hidden=False)
 
     # Open another window with no menu so widget should hide text
@@ -81,9 +79,7 @@ def test_global_menu(manager, backend_name):
     wait_for_text(manager, hidden=True)
 
     # Focus back on window with menu and check text appears
-    manager.c.widget["globalmenu"].eval(
-        f"asyncio.create_task(self.get_window_menu({window['id']}))"
-    )
+    manager.c.widget["globalmenu"].eval(f"create_task(self.get_window_menu({window['id']}))")
     wait_for_text(manager, hidden=False)
 
     # Left-click on top menu to open menu window


### PR DESCRIPTION
Previous menus still had callbacks attached to layout changes. These callbacks need to be removed when finalising the widget.

Closes https://github.com/qtile/qtile/issues/4833
