### PR TITLE
Fix border decoration bug

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-07-16: [BUGFIX] Fix bug where border decorations failed on x11 if user did not have wayland libraries installed
 2024-07-12: [RELEASE] v0.27.0 release - compatible with qtile 0.27.0
 2024-07-12: [BUGFIX] Fix bug where conditional border could resize window
 2024-07-07: [FEATURE] Add `RoundedCorners` border decoration (Wayland only)

--- a/qtile_extras/layout/decorations/__init__.py
+++ b/qtile_extras/layout/decorations/__init__.py
@@ -44,7 +44,7 @@ def inject_border_methods():
     if qtile.core.name == "wayland":
         from libqtile.backend.wayland.window import Window
 
-        from qtile_extras.layout.decorations.injections import (
+        from qtile_extras.layout.decorations.injections_wayland import (
             wayland_paint_borders,
             wayland_window_init,
         )

--- a/qtile_extras/layout/decorations/__init__.py
+++ b/qtile_extras/layout/decorations/__init__.py
@@ -18,6 +18,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 from libqtile import hook
+from libqtile.log_utils import logger
 
 from qtile_extras.layout.decorations.borders import (  # noqa: F401
     ConditionalBorder,
@@ -38,6 +39,8 @@ from qtile_extras.layout.decorations.borders import (  # noqa: F401
 def inject_border_methods():
     from libqtile import qtile
 
+    logger.debug("qtile_extras: Running inject_border_methods.")
+
     if qtile.core.name == "wayland":
         from libqtile.backend.wayland.window import Window
 
@@ -46,6 +49,7 @@ def inject_border_methods():
             wayland_window_init,
         )
 
+        logger.debug("qtile_extras: Injecting wayland border methods.")
         Window.__init__ = wayland_window_init
         Window.paint_borders = wayland_paint_borders
 
@@ -54,6 +58,7 @@ def inject_border_methods():
 
         from qtile_extras.layout.decorations.injections import x11_paint_borders
 
+        logger.debug("qtile_extras: Injecting x11 border methods.")
         XWindow.paint_borders = x11_paint_borders
 
 
@@ -63,10 +68,13 @@ def inject_border_width_methods():
 
     from qtile_extras.layout.decorations.injections import new_place
 
+    logger.debug("qtile_extras: Running inject_border_width methods.")
+
     if qtile.core.name == "wayland":
         from libqtile.backend.wayland.xdgwindow import XdgWindow
         from libqtile.backend.wayland.xwindow import XWindow
 
+        logger.debug("qtile_extras: Injecting wayland border width methods.")
         for base in (XdgWindow, XWindow):
             base._place = base.place
             base.place = new_place
@@ -74,5 +82,6 @@ def inject_border_width_methods():
     else:
         from libqtile.backend.x11.window import _Window
 
+        logger.debug("qtile_extras: Injecting x11 border methods.")
         _Window._place = _Window.place
         _Window.place = new_place

--- a/qtile_extras/layout/decorations/injections.py
+++ b/qtile_extras/layout/decorations/injections.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING
 import xcffib
 from libqtile import qtile
 from libqtile.backend.wayland.window import SceneRect, Window, _rgb
+from libqtile.log_utils import logger
 from xcffib.wrappers import GContextID, PixmapID
 
 from qtile_extras.layout.decorations.borders import (
@@ -42,11 +43,13 @@ old_wayland_window_init = Window.__init__
 
 
 def wayland_window_init(self, core: Core, qtile: Qtile, surface: S):
+    logger.debug("qtile_extras: Running injected wayland window init.")
     old_wayland_window_init(self, core, qtile, surface)
     self._border_styles = {}
 
 
 def wayland_paint_borders(self, colors: ColorsType | None, width: int) -> None:
+    logger.debug("qtile_extras: Running injected wayland paint borders.")
     if not colors:
         colors = []
         width = 0
@@ -156,6 +159,7 @@ def x11_paint_borders(self, depth, colors, borderwidth, width, height):
     """
     This method is used only by the managing Window class.
     """
+    logger.debug("qtile_extras: Running injected x11 paint borders.")
     self.set_property("_NET_FRAME_EXTENTS", [borderwidth] * 4)
 
     if not colors or not borderwidth:
@@ -226,6 +230,7 @@ def new_place(
     margin=None,
     respect_hints=False,
 ):
+    logger.debug("qtile_extras: Running injected window place method.")
     if isinstance(borderwidth, ConditionalBorderWidth):
         old = getattr(self, "_old_bw", borderwidth.default)
         newborder = borderwidth.get_border_for_window(self)

--- a/qtile_extras/layout/decorations/injections.py
+++ b/qtile_extras/layout/decorations/injections.py
@@ -20,11 +20,8 @@
 # SOFTWARE.
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
-
 import xcffib
 from libqtile import qtile
-from libqtile.backend.wayland.window import SceneRect, Window, _rgb
 from libqtile.log_utils import logger
 from xcffib.wrappers import GContextID, PixmapID
 
@@ -33,126 +30,6 @@ from qtile_extras.layout.decorations.borders import (
     ConditionalBorderWidth,
     _BorderStyle,
 )
-
-if TYPE_CHECKING:
-    from libqtile.backend.wayland.window import Core, Qtile, S
-    from libqtile.utils import ColorsType
-
-
-old_wayland_window_init = Window.__init__
-
-
-def wayland_window_init(self, core: Core, qtile: Qtile, surface: S):
-    logger.debug("qtile_extras: Running injected wayland window init.")
-    old_wayland_window_init(self, core, qtile, surface)
-    self._border_styles = {}
-
-
-def wayland_paint_borders(self, colors: ColorsType | None, width: int) -> None:
-    logger.debug("qtile_extras: Running injected wayland paint borders.")
-    if not colors:
-        colors = []
-        width = 0
-
-    if not isinstance(colors, list):
-        colors = [colors]
-
-    colors = [c.compare(self) if isinstance(c, ConditionalBorder) else c for c in colors]
-
-    if self.tree:
-        self.tree.node.set_position(width, width)
-    self.bordercolor = colors
-    self.borderwidth = width
-
-    if width == 0:
-        for rects in self._borders:
-            for rect in rects:
-                rect.node.destroy()
-        self._borders.clear()
-        return
-
-    if len(colors) > width:
-        colors = colors[:width]
-
-    num = len(colors)
-    old_borders = self._borders
-    new_borders = []
-    widths = [width // num] * num
-    for i in range(width % num):
-        widths[i] += 1
-
-    outer_w = self.width + width * 2
-    outer_h = self.height + width * 2
-    coord = 0
-
-    for i, color in enumerate(colors):
-        bw = widths[i]
-        if isinstance(color, _BorderStyle):
-            # Tidy up old data
-            if color in self._border_styles:
-                _old_buffer, old_surface = self._border_styles.pop(color)
-                if old_surface is not None:
-                    old_surface.finish()
-
-            scenes, image_buffer, surface = color._wayland_draw(
-                self,
-                outer_w,
-                outer_h,
-                bw,
-                coord,
-                coord,
-                outer_w - coord * 2,
-                outer_h - coord * 2,
-            )
-
-            # Keep reference to border objects
-            self._border_styles[color] = (image_buffer, surface)
-            new_borders.append(scenes)
-        else:
-            color_ = _rgb(color)
-
-            # [x, y, width, height] for N, E, S, W
-            geometries = (
-                (coord, coord, outer_w - coord * 2, bw),
-                (outer_w - bw - coord, bw + coord, bw, outer_h - bw * 2 - coord * 2),
-                (coord, outer_h - bw - coord, outer_w - coord * 2, bw),
-                (coord, bw + coord, bw, outer_h - bw * 2 - coord * 2),
-            )
-
-            if old_borders:
-                rects = old_borders.pop(0)
-                for (x, y, w, h), rect in zip(geometries, rects):
-                    if isinstance(rect, SceneRect):
-                        rect.set_color(color_)
-                        rect.set_size(w, h)
-                        rect.node.set_position(x, y)
-                        needs_new_rects = False
-                    else:
-                        rect.node.destroy()
-                        needs_new_rects = True
-            else:
-                needs_new_rects = True
-
-            if needs_new_rects:
-                rects = []
-                for x, y, w, h in geometries:
-                    rect = SceneRect(self.container, w, h, color_)
-                    rect.node.set_position(x, y)
-                    rects.append(rect)
-
-            new_borders.append(rects)
-        coord += bw
-
-    for rects in old_borders:
-        for rect in rects:
-            rect.node.destroy()
-
-    # Ensure the window contents and any nested surfaces are drawn above the
-    # borders.
-    if self.tree:
-        self.tree.node.raise_to_top()
-
-    self._borders = new_borders
 
 
 def x11_paint_borders(self, depth, colors, borderwidth, width, height):

--- a/qtile_extras/layout/decorations/injections_wayland.py
+++ b/qtile_extras/layout/decorations/injections_wayland.py
@@ -1,0 +1,148 @@
+# Copyright (c) 2021 Matt Colligan
+# Copyright (c) 2024 elParaguayo
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from libqtile.backend.wayland.window import SceneRect, Window, _rgb
+from libqtile.log_utils import logger
+
+from qtile_extras.layout.decorations.borders import ConditionalBorder, _BorderStyle
+
+if TYPE_CHECKING:
+    from libqtile.backend.wayland.window import Core, Qtile, S
+    from libqtile.utils import ColorsType
+
+
+old_wayland_window_init = Window.__init__
+
+
+def wayland_window_init(self, core: Core, qtile: Qtile, surface: S):
+    logger.debug("qtile_extras: Running injected wayland window init.")
+    old_wayland_window_init(self, core, qtile, surface)
+    self._border_styles = {}
+
+
+def wayland_paint_borders(self, colors: ColorsType | None, width: int) -> None:
+    logger.debug("qtile_extras: Running injected wayland paint borders.")
+    if not colors:
+        colors = []
+        width = 0
+
+    if not isinstance(colors, list):
+        colors = [colors]
+
+    colors = [c.compare(self) if isinstance(c, ConditionalBorder) else c for c in colors]
+
+    if self.tree:
+        self.tree.node.set_position(width, width)
+    self.bordercolor = colors
+    self.borderwidth = width
+
+    if width == 0:
+        for rects in self._borders:
+            for rect in rects:
+                rect.node.destroy()
+        self._borders.clear()
+        return
+
+    if len(colors) > width:
+        colors = colors[:width]
+
+    num = len(colors)
+    old_borders = self._borders
+    new_borders = []
+    widths = [width // num] * num
+    for i in range(width % num):
+        widths[i] += 1
+
+    outer_w = self.width + width * 2
+    outer_h = self.height + width * 2
+    coord = 0
+
+    for i, color in enumerate(colors):
+        bw = widths[i]
+        if isinstance(color, _BorderStyle):
+            # Tidy up old data
+            if color in self._border_styles:
+                _old_buffer, old_surface = self._border_styles.pop(color)
+                if old_surface is not None:
+                    old_surface.finish()
+
+            scenes, image_buffer, surface = color._wayland_draw(
+                self,
+                outer_w,
+                outer_h,
+                bw,
+                coord,
+                coord,
+                outer_w - coord * 2,
+                outer_h - coord * 2,
+            )
+
+            # Keep reference to border objects
+            self._border_styles[color] = (image_buffer, surface)
+            new_borders.append(scenes)
+        else:
+            color_ = _rgb(color)
+
+            # [x, y, width, height] for N, E, S, W
+            geometries = (
+                (coord, coord, outer_w - coord * 2, bw),
+                (outer_w - bw - coord, bw + coord, bw, outer_h - bw * 2 - coord * 2),
+                (coord, outer_h - bw - coord, outer_w - coord * 2, bw),
+                (coord, bw + coord, bw, outer_h - bw * 2 - coord * 2),
+            )
+
+            if old_borders:
+                rects = old_borders.pop(0)
+                for (x, y, w, h), rect in zip(geometries, rects):
+                    if isinstance(rect, SceneRect):
+                        rect.set_color(color_)
+                        rect.set_size(w, h)
+                        rect.node.set_position(x, y)
+                        needs_new_rects = False
+                    else:
+                        rect.node.destroy()
+                        needs_new_rects = True
+            else:
+                needs_new_rects = True
+
+            if needs_new_rects:
+                rects = []
+                for x, y, w, h in geometries:
+                    rect = SceneRect(self.container, w, h, color_)
+                    rect.node.set_position(x, y)
+                    rects.append(rect)
+
+            new_borders.append(rects)
+        coord += bw
+
+    for rects in old_borders:
+        for rect in rects:
+            rect.node.destroy()
+
+    # Ensure the window contents and any nested surfaces are drawn above the
+    # borders.
+    if self.tree:
+        self.tree.node.raise_to_top()
+
+    self._borders = new_borders


### PR DESCRIPTION
Where a user did not have wayland libraries installed then loading border decorations would fail as the injections module tried to import some wayland classes. This PR fixes the problem by splitting wayland specific code into a separate module which is only imported if the wayland backend is being run.