### PR TITLE
Fix volume widget bug - unnecessary display

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-07-18: [BUGFIX] Fix volume widgets bug volume display triggered on opening apps using sound device
 2024-07-16: [POST RELEASE] v0.27.0.post1 incorporates bugfix below. Still compatible with v0.27.0
 2024-07-16: [BUGFIX] Fix bug where border decorations failed on x11 if user did not have wayland libraries installed
 2024-07-12: [RELEASE] v0.27.0 release - compatible with qtile 0.27.0

--- a/qtile_extras/widget/alsavolumecontrol.py
+++ b/qtile_extras/widget/alsavolumecontrol.py
@@ -76,15 +76,14 @@ class ALSAWidget(_Volume):
 
         # If volume or mute status has changed
         # then we need to trigger callback
-        if any([self.volume != self.oldvol, self.muted != self.oldmute]):
+        if (self.volume, self.muted) != self._previous_state:
             if not self.first_run:
                 self.status_change(self.volume, self.muted)
             else:
                 self.first_run = False
 
             # Record old values
-            self.oldvol = self.volume
-            self.oldmute = self.muted
+            self._previous_state = (self.volume, self.muted)
 
     def get_volume(self):
         cmd = "amixer get {}".format(self.device)

--- a/qtile_extras/widget/base.py
+++ b/qtile_extras/widget/base.py
@@ -107,8 +107,7 @@ class _Volume(base._Widget, ExtendedPopupMixin, ProgressBarMixin):
         # Set up necessary variables
         self.muted = False
         self.volume = -1
-        self.oldvol = -1
-        self.oldmute = False
+        self._previous_state = (-1.0, -1)
 
         # Variable to store icons
         self.surfaces = {}
@@ -186,7 +185,10 @@ class _Volume(base._Widget, ExtendedPopupMixin, ProgressBarMixin):
         return width
 
     def status_change(self, vol, muted):
-        # Something's changed so let's update display
+        if (vol, muted) == self._previous_state:
+            return
+
+        # Something's changed
         # Unhide bar
         self.hidden = False
 
@@ -199,6 +201,7 @@ class _Volume(base._Widget, ExtendedPopupMixin, ProgressBarMixin):
         # Get new values
         self.volume = vol
         self.muted = muted
+        self._previous_state = (vol, muted)
 
         # Restart timer
         self.set_refresh_timer()


### PR DESCRIPTION
The pulsevolume widget receives a notification from the server when a new app accesses the sound device. This triggers the callback in the widget but, as the widget does not check to see if the volume has changed, the volume is always displayed.

This PR fixes the issue by only displaying the volume when there is a change.