### PR TITLE
Add `visible` option to GroupBox2

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2024-07-22: [FEATURE] Add ability to toggle visibility of groups in `GroupBox2` widget
 2024-07-18: [BUGFIX] Fix volume widgets bug volume display triggered on opening apps using sound device
 2024-07-16: [POST RELEASE] v0.27.0.post1 incorporates bugfix below. Still compatible with v0.27.0
 2024-07-16: [BUGFIX] Fix bug where border decorations failed on x11 if user did not have wayland libraries installed

--- a/test/widget/test_groupbox2.py
+++ b/test/widget/test_groupbox2.py
@@ -423,3 +423,30 @@ def test_visible_groups(gbmanager):
 def test_box_size(gbmanager):
     info = gbmanager.c.widget["groupbox2"].info()
     assert info["width"] == 250
+
+
+@pytest.mark.parametrize(
+    "gbmanager",
+    [
+        {
+            "rules": [
+                GroupBoxRule(visible=True).when(focused=True),
+                GroupBoxRule(visible=False).when(occupied=False),
+            ]
+        }
+    ],
+    indirect=True,
+)
+def test_box_visibility(gbmanager):
+    def text():
+        return gbmanager.c.widget["groupbox2"].info()["text"]
+
+    assert text() == "a|c"
+
+    gbmanager.c.group["b"].toscreen()
+    assert text() == "b|c"
+
+    gbmanager.c.group["c"].toscreen()
+    gbmanager.c.window.kill()
+    gbmanager.c.group["d"].toscreen()
+    assert text() == "d"


### PR DESCRIPTION
Rules now allow ability to hide boxes from the widget.