### PR TITLE
Update CurrentLayout widget

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,5 @@
+2027-07-12: [BREAKING CHANGE] Qtile has removed `CurrentLayoutIcon` as it is now part of
+                              `CurrentLayout`. qtile-extras has been updated to match.
 2027-06-15: [FEATURE] Add `Tetris` widget
 2026-06-10: [RELEASE] v0.32.0 release - compatible with qtile 0.32.0
 2026-06-08: [FEATURE] Add `Pong` widget

--- a/qtile_extras/widget/__init__.py
+++ b/qtile_extras/widget/__init__.py
@@ -33,7 +33,7 @@ widgets = {
     "Bluetooth": "bluetooth",
     "BrightnessControl": "brightnesscontrol",
     "ContinuousPoll": "continuous_poll",
-    "CurrentLayoutIcon": "currentlayout",
+    "CurrentLayout": "currentlayout",
     "CPUGraph": "graph",
     "GithubNotifications": "githubnotifications",
     "GlobalMenu": "globalmenu",

--- a/qtile_extras/widget/decorations.py
+++ b/qtile_extras/widget/decorations.py
@@ -598,7 +598,7 @@ class PowerLineDecoration(_Decoration):
             Screen(
                 top=Bar(
                     [
-                        widget.CurrentLayoutIcon(background="000000", **powerline),
+                        widget.CurrentLayout(icon_first=True, background="000000", **powerline),
                         widget.WindowName(background="222222", **powerline),
                         widget.Clock(background="444444", **powerline),
                         widget.QuickExit(background="666666")

--- a/test/widget/docs_screenshots/ss_currentlayouticon.py
+++ b/test/widget/docs_screenshots/ss_currentlayouticon.py
@@ -19,20 +19,21 @@
 # SOFTWARE.
 import pytest
 
-from qtile_extras.widget.currentlayout import CurrentLayoutIcon
+from qtile_extras.widget.currentlayout import CurrentLayout
 from test.widget.docs_screenshots.conftest import widget_config
 
 
 @pytest.fixture
 def widget():
-    yield CurrentLayoutIcon
+    yield CurrentLayout
 
 
 @widget_config(
     [
         {},
-        {"use_mask": True, "foreground": "0ff"},
-        {"use_mask": True, "foreground": ["f0f", "00f", "0ff"]},
+        {"icon_first": True},
+        {"use_mask": True, "icon_first": True, "foreground": "0ff"},
+        {"use_mask": True, "icon_first": True, "foreground": ["f0f", "00f", "0ff"]},
     ]
 )
 def ss_currentlayouticon(screenshot_manager):

--- a/test/widget/test_currentlayouticon.py
+++ b/test/widget/test_currentlayouticon.py
@@ -61,8 +61,8 @@ def temp_icons(layout_list):
 @pytest.fixture(scope="function")
 def currentlayout_manager(request, layout_list, manager_nospawn):
     # We need to enable the mask here otherwise the widget is just the default qtile one.
-    widget = qtile_extras.widget.currentlayout.CurrentLayoutIcon(
-        **{"use_mask": True, **getattr(request, "param", dict())}
+    widget = qtile_extras.widget.currentlayout.CurrentLayout(
+        **{"use_mask": True, "icon_first": True, **getattr(request, "param", dict())}
     )
 
     class CurrentLayoutConfig(libqtile.confreader.Config):
@@ -98,7 +98,7 @@ def currentlayout_manager(request, layout_list, manager_nospawn):
     indirect=["currentlayout_manager"],
 )
 def test_currentlayouticon_icon_size(currentlayout_manager, expected):
-    info = currentlayout_manager.c.widget["currentlayouticon"].info()
+    info = currentlayout_manager.c.widget["currentlayout"].info()
     assert info["length"] == expected
 
 


### PR DESCRIPTION
Updated to work with updates in qtile main repo where `CurrentLayout` and `CurrentLayoutIcon` are combined in a single widget.