### PR TITLE
fix: remove offset calls and use new draw_at_default_position function

### DIFF
--- a/docs/manual/how_to/img-mask.rst
+++ b/docs/manual/how_to/img-mask.rst
@@ -47,11 +47,7 @@ The example below shows a simple widget using this class to display three icons.
                 self.img.draw(colour=col, x=offset)
                 offset += self.img.width
 
-            self.drawer.draw(
-                offsetx=self.offset,
-                offsety=self.offsety,
-                width=self.length
-            )
+            self.draw_at_default_position()
 
 Placing an instance of ``MaskWidget()`` in your bar will then give you something like this:
 

--- a/qtile_extras/widget/analogueclock.py
+++ b/qtile_extras/widget/analogueclock.py
@@ -174,6 +174,6 @@ class AnalogueClock(base._Widget):
         if self.second_size:
             self.draw_seconds()
 
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
         self.previous_clock = self.clock_string

--- a/qtile_extras/widget/animatedimage.py
+++ b/qtile_extras/widget/animatedimage.py
@@ -121,11 +121,7 @@ class AnimatedImage(base._Widget, base.MarginMixin):
         self.drawer.ctx.set_source(img.pattern)
         self.drawer.ctx.paint()
         self.drawer.ctx.restore()
-
-        if self.bar.horizontal:
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
-        else:
-            self.drawer.draw(offsety=self.offset, offsetx=self.offsetx, height=self.width)
+        self.draw_at_default_position()
 
         if self._do_loop and (self._timer is None or not self._timer._scheduled):
             self._queue_next()

--- a/qtile_extras/widget/base.py
+++ b/qtile_extras/widget/base.py
@@ -341,7 +341,7 @@ class _Volume(base._Widget, ExtendedPopupMixin, ProgressBarMixin):
 
             self.set_hide_timer()
 
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def refresh(self):
         # Check the volume levels to see if they've changed

--- a/qtile_extras/widget/brightnesscontrol.py
+++ b/qtile_extras/widget/brightnesscontrol.py
@@ -321,7 +321,7 @@ class BrightnessControl(base._Widget, ExtendedPopupMixin, ProgressBarMixin):
         self.draw_bar(bar_colour=bar_colour, bar_text=bar_text, bar_value=value)
 
         # Redraw the bar
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def set_timer(self):
         # Cancel old timer

--- a/qtile_extras/widget/currentlayout.py
+++ b/qtile_extras/widget/currentlayout.py
@@ -117,9 +117,7 @@ class CurrentLayout(_CurrentLayout):
             self.drawer.ctx.set_source(surface.pattern)
             self.drawer.ctx.paint()
         self.drawer.ctx.restore()
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()
 
 
 class CurrentLayoutIcon(CurrentLayout):

--- a/qtile_extras/widget/githubnotifications.py
+++ b/qtile_extras/widget/githubnotifications.py
@@ -178,7 +178,7 @@ class GithubNotifications(base._Widget):
         self.drawer.clear(self.background or self.bar.background)
         offsety = (self.bar.height - self.img.height) // 2
         self.img.draw(colour=self.icon_colour, x=self.padding, y=offsety)
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     @expose_command()
     def reload_token(self):

--- a/qtile_extras/widget/globalmenu.py
+++ b/qtile_extras/widget/globalmenu.py
@@ -173,7 +173,7 @@ class GlobalMenu(base._TextBox, DbusMenuMixin):
             item.draw(offset, int(self.bar.height / 2.0 - self.layout.height / 2.0) + 1)
             offset += item.width + padding
 
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.width)
+        self.draw_at_default_position()
 
     def calculate_length(self):
         if not self.items:

--- a/qtile_extras/widget/groupbox2.py
+++ b/qtile_extras/widget/groupbox2.py
@@ -997,9 +997,7 @@ class GroupBox2(base._Widget, base.MarginMixin, base.PaddingMixin):
             box.draw((offset, 0) if self.bar.horizontal else (0, offset))
             offset += box.size
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, height=self.height, width=self.width
-        )
+        self.draw_at_default_position()
 
     def button_press(self, x, y, button):
         self.click_pos = x, y

--- a/qtile_extras/widget/image.py
+++ b/qtile_extras/widget/image.py
@@ -106,10 +106,7 @@ class Image(QtileImage):
             self.drawer.ctx.paint()
         self.drawer.ctx.restore()
 
-        if self.bar.horizontal:
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
-        else:
-            self.drawer.draw(offsety=self.offset, offsetx=self.offsetx, height=self.width)
+        self.draw_at_default_position()
 
     def calculate_length(self):
         if self.img is None:

--- a/qtile_extras/widget/iwd.py
+++ b/qtile_extras/widget/iwd.py
@@ -563,9 +563,7 @@ class IWD(base._TextBox, base.MarginMixin, MenuMixin, GraphicalWifiMixin, Connec
         if self.show_text:
             self.layout.draw(offset, int(self.bar.height / 2.0 - self.layout.height / 2.0) + 1)
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, width=self.width, height=self.height
-        )
+        self.draw_at_default_position()
 
     def _get_menu_items(self):
         menu_items = []

--- a/qtile_extras/widget/livefootballscores.py
+++ b/qtile_extras/widget/livefootballscores.py
@@ -516,7 +516,7 @@ class LiveFootballScores(base._Widget, base.MarginMixin, ExtendedPopupMixin, Men
                     self.draw_underline(m)
 
         # # Redraw the bar
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def draw_goal(self, home):
         offset = 0 if home else (self.calculate_length() - 2)

--- a/qtile_extras/widget/network.py
+++ b/qtile_extras/widget/network.py
@@ -133,7 +133,7 @@ class WiFiIcon(base._Widget, base.PaddingMixin, GraphicalWifiMixin, ConnectionCh
         )
         if self._show_text:
             self.draw_wifi_text()
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def get_wifi_text(self, size_only=False):
         text = f"{self.essid} ({self.percent * 100:.0f}%)"

--- a/qtile_extras/widget/pong.py
+++ b/qtile_extras/widget/pong.py
@@ -286,9 +286,7 @@ class Pong(base._Widget):
 
             self.ball.draw(self.drawer)
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, height=self.height, width=self.width
-        )
+        self.draw_at_default_position()
 
     @expose_command
     def start(self):

--- a/qtile_extras/widget/snake.py
+++ b/qtile_extras/widget/snake.py
@@ -226,9 +226,7 @@ class Snake(base._Widget):
         self._finish_draw()
 
     def _finish_draw(self):
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, height=self.height, width=self.width
-        )
+        self.draw_at_default_position()
 
     @expose_command
     def start(self):

--- a/qtile_extras/widget/snapcast.py
+++ b/qtile_extras/widget/snapcast.py
@@ -314,7 +314,7 @@ class SnapCast(base._Widget, MenuMixin):
 
         offsety = (self.bar.height - self.img.height) // 2
         self.img.draw(colour=self.status_colour, x=self.padding, y=offsety)
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def finalize(self):
         self.finalising = True

--- a/qtile_extras/widget/strava.py
+++ b/qtile_extras/widget/strava.py
@@ -238,7 +238,7 @@ class StravaWidget(base._Widget, base.MarginMixin):
             # Draw it
             layout.draw(x_offset + self.margin_x, y_offset)
 
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def button_press(self, x, y, button):
         self.show_popup_summary()

--- a/qtile_extras/widget/syncthing.py
+++ b/qtile_extras/widget/syncthing.py
@@ -195,4 +195,4 @@ class Syncthing(base._Widget, ProgressBarMixin):
                 x_offset=x_offset, bar_text=self.bar_text_format.format(percentage=self.bar_value)
             )
 
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()

--- a/qtile_extras/widget/systray.py
+++ b/qtile_extras/widget/systray.py
@@ -41,7 +41,7 @@ class Systray(widget.Systray):
     def draw(self):
         offset = self.padding
         self.drawer.clear(self.background or self.bar.background)
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
         for pos, icon in enumerate(self.tray_icons):
             # Check if we're using a decoration and set backpixel colour accordingly
             rect_decs = [d for d in self.decorations if isinstance(d, RectDecoration)]

--- a/qtile_extras/widget/tetris.py
+++ b/qtile_extras/widget/tetris.py
@@ -461,9 +461,7 @@ class Tetris(base._Widget):
             if self.blockify:
                 self.draw_gridlines()
 
-        self.drawer.draw(
-            offsetx=self.offsetx, offsety=self.offsety, height=self.height, width=self.width
-        )
+        self.draw_at_default_position()
 
     @expose_command
     def start(self):

--- a/qtile_extras/widget/tvheadend.py
+++ b/qtile_extras/widget/tvheadend.py
@@ -244,7 +244,7 @@ class TVHWidget(base._Widget, base.MarginMixin):
         elif self.is_recording:
             self.draw_highlight(top=False, colour=self.recording_colour)
 
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     @property
     def is_recording(self):

--- a/qtile_extras/widget/unitstatus.py
+++ b/qtile_extras/widget/unitstatus.py
@@ -206,7 +206,7 @@ class UnitStatus(base._Widget, base.PaddingMixin, base.MarginMixin):
             self.colours[self.state],
         )
 
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.width)
+        self.draw_at_default_position()
 
     # This is just Drawer's "_rounded_rect" but with a bigger corner radius
     def circle(self, x, y, width, height, linewidth):

--- a/qtile_extras/widget/upower.py
+++ b/qtile_extras/widget/upower.py
@@ -385,7 +385,7 @@ class UPowerWidget(base._Widget):
                 offset += layout.width
 
         # Redraw the bar
-        self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
     def secs_to_hm(self, secs):
         # Basic maths to convert seconds to h:mm format

--- a/qtile_extras/widget/visualiser.py
+++ b/qtile_extras/widget/visualiser.py
@@ -231,7 +231,7 @@ class Visualiser(base._Widget):
         # If the processes aren't running, trying to access the shared memory will fail.
         if not self._procs_started:
             self.drawer.clear(self.background or self.bar.background)
-            self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.length)
+            self.draw_at_default_position()
             return
 
         # We need to lock the redraw to our set framerate. We can't rely solely on timers
@@ -256,7 +256,7 @@ class Visualiser(base._Widget):
         self.drawer.clear(self.background or self.bar.background)
         self.drawer.ctx.set_source_surface(surface, 0, self.y_offset)
         self.drawer.ctx.paint()
-        self.drawer.draw(offsetx=self.offsetx, offsety=self.offsety, width=self.length)
+        self.draw_at_default_position()
 
         self._timer = self.timeout_add(self._interval, self.loop)
 

--- a/test/test_images.py
+++ b/test/test_images.py
@@ -58,7 +58,7 @@ def test_draw(minimal_conf_noscreen, manager_nospawn):
         def draw(self):
             self.drawer.clear(self.background or self.bar.background)
             self.img.draw()
-            self.drawer.draw(offsetx=self.offset, offsety=self.offsety, width=self.length)
+            self.draw_at_default_position()
 
     config = minimal_conf_noscreen
     config.screens = [libqtile.config.Screen(top=bar.Bar([MaskWidget()], 10))]


### PR DESCRIPTION
As in https://github.com/qtile/qtile/pull/5342, there is the need to fix all calls to the offset property in the widgets but to make this better use the new `draw_at_default_position` function.

I have tested the CI ([see here](https://github.com/RFCreate/qtile-extras/actions/runs/16294538552)) and the changes work fine using the code from qtile's PR.