### PR TITLE
Fix ToolTip

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,4 @@
+2025-08-05: [BUGFIX] Fix `TooltipMixin` bug where text could not be set due to change in qtile
 2025-07-27: [BREAKING CHANGE] Drop support for python < 3.12 (following same change in qtile)
 2025-07-25: [RELEASE] v0.33.0 release - compatible with qtile 0.33.0
 2025-07-21: [BREAKING CHNAGE] More changes to `CurrentLayout` in qtile so you need latest

--- a/qtile_extras/widget/mixins/__init__.py
+++ b/qtile_extras/widget/mixins/__init__.py
@@ -121,7 +121,7 @@ class TooltipMixin(_BaseMixin):
         )
 
         # Size the popup
-        self._tooltip.text = self.tooltip_text
+        self._tooltip.layout.text = self.tooltip_text
 
         height = self._tooltip.layout.height + (2 * self._tooltip.vertical_padding)
         width = self._tooltip.layout.width + (2 * self._tooltip.horizontal_padding)
@@ -173,9 +173,10 @@ class TooltipMixin(_BaseMixin):
             return
 
         else:
-            self._tooltip.hide()
-            self._tooltip.kill()
-            self._tooltip = None
+            if self._tooltip is not None:
+                self._tooltip.hide()
+                self._tooltip.kill()
+                self._tooltip = None
             self._tooltip_timer = None
 
 


### PR DESCRIPTION
https://github.com/qtile/qtile/pull/5325 made changes to layout text setters and getters. Although we updated qtile-extras, we missed the tooltip mixin setting its text.

Fixes #441