### PR TITLE
Remove unpack of widget.eval in tests

### DIFF
--- a/test/backend/wayland/conftest.py
+++ b/test/backend/wayland/conftest.py
@@ -63,8 +63,7 @@ class WaylandBackend(Backend):
 
     def configure(self, manager):
         """This backend needs to get WAYLAND_DISPLAY variable."""
-        success, display = manager.c.eval("self.core.display_name")
-        assert success
+        display = manager.c.eval("self.core.display_name")
         self.env["WAYLAND_DISPLAY"] = display
 
     def fake_click(self, x, y):

--- a/test/popup/test_menu.py
+++ b/test/popup/test_menu.py
@@ -21,7 +21,7 @@ import textwrap
 
 
 def test_popup_menu_from_dbus(manager):
-    success, msg = manager.c.eval(
+    manager.c.eval(
         textwrap.dedent(
             """
         from qtile_extras.popup.menu import PopupMenu
@@ -91,7 +91,6 @@ def test_popup_menu_from_dbus(manager):
     """
         )
     )
-    assert success, msg
 
     layout = manager.c.internal_windows()[0]
     assert layout["name"] == "popupmenu"

--- a/test/popup/test_toolkit.py
+++ b/test/popup/test_toolkit.py
@@ -133,7 +133,7 @@ def test_absolute_layout(manager):
     """
     )
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     control = info["controls"][0]
     assert control["x"] == 10
@@ -164,7 +164,7 @@ def test_relative_layout(manager):
     """
     )
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     control = info["controls"][0]
     assert control["x"] == 20
@@ -197,7 +197,7 @@ def test_grid_layout(manager):
     """
     )
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     control = info["controls"][0]
     assert control["x"] == 50
@@ -272,7 +272,7 @@ def test_multiple_screens(manager):
 
     # Show popup on screen 0 which is at (0, 0) and has dimensions of (400, 600)
     manager.c.eval("self.popup.show(centered=True)")
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["width"] == 200
     assert info["height"] == 200
@@ -284,7 +284,7 @@ def test_multiple_screens(manager):
     manager.c.eval("self.popup.hide()")
     manager.c.to_screen(1)
     manager.c.eval("self.popup.show(centered=True)")
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["width"] == 200
     assert info["height"] == 200
@@ -296,7 +296,7 @@ def test_multiple_screens(manager):
     manager.c.eval("self.popup.hide()")
     manager.c.to_screen(0)
     manager.c.eval("self.popup.show()")
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["width"] == 200
     assert info["height"] == 200
@@ -308,7 +308,7 @@ def test_multiple_screens(manager):
     manager.c.eval("self.popup.hide()")
     manager.c.to_screen(1)
     manager.c.eval("self.popup.show()")
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["width"] == 200
     assert info["height"] == 200
@@ -319,7 +319,7 @@ def test_multiple_screens(manager):
     manager.c.eval("self.popup.hide()")
     manager.c.to_screen(0)
     manager.c.eval("self.popup.show(x=500, y=200)")
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["width"] == 200
     assert info["height"] == 200
@@ -364,7 +364,7 @@ def test_popup_widgets(manager):
     """
     )
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
 
     for control in info["controls"]:
@@ -411,7 +411,7 @@ def test_popup_widgets_vertical(manager):
     """
     )
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
 
     for control in info["controls"]:
@@ -503,7 +503,7 @@ def test_popup_positioning_relative(manager_nospawn, position, opts, expected):
     )
 
     manager_nospawn.c.eval(layout)
-    _, info = manager_nospawn.c.eval("self.popup.info()")
+    info = manager_nospawn.c.eval("self.popup.info()")
     info = eval(info)
 
     assert (info["x"], info["y"]) == expected
@@ -525,7 +525,7 @@ def test_popup_positioning_centered(manager):
     """
     )
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
 
     assert (info["x"], info["y"]) == (300, 200)
@@ -578,17 +578,15 @@ def test_popup_update_controls(manager):
     )
 
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["controls"][0]["text"] == "Original Text"
     assert info["controls"][1]["value"] == 0.5
     assert info["controls"][2]["value"] == 0.25
 
     # Update controls
-    _, out = manager.c.eval(
-        "self.popup.update_controls(textbox1='New Text', slider1=0.8, progress1=1)"
-    )
-    _, info = manager.c.eval("self.popup.info()")
+    manager.c.eval("self.popup.update_controls(textbox1='New Text', slider1=0.8, progress1=1)")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["controls"][0]["text"] == "New Text"
     assert info["controls"][1]["value"] == 0.8
@@ -637,20 +635,20 @@ def test_bind_callbacks_and_overlap(manager):
     )
 
     manager.c.eval(layout)
-    _, info = manager.c.eval("self.popup.info()")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["controls"][0]["value"] == 0.5
     assert info["controls"][1]["value"] == 0.25
 
     # Update controls
-    _, out = manager.c.eval(
+    manager.c.eval(
         "self.popup.bind_callbacks("
         "slider1={'Button1': lambda p=self.popup: p.update_controls(slider1=0.1)},"
         "progress1={'Button1': lambda p=self.popup: p.update_controls(progress1=0.9)}"
         ")"
     )
-    _, out = manager.c.eval("self.popup.process_button_click(110, 20, 1)")
-    _, info = manager.c.eval("self.popup.info()")
+    manager.c.eval("self.popup.process_button_click(110, 20, 1)")
+    info = manager.c.eval("self.popup.info()")
     info = eval(info)
     assert info["controls"][0]["value"] == 0.1
     assert info["controls"][1]["value"] == 0.9

--- a/test/widget/decorations/test_widget_decorations.py
+++ b/test/widget/decorations/test_widget_decorations.py
@@ -90,7 +90,7 @@ def test_decorations(manager_nospawn, minimal_conf_noscreen):
 
     manager_nospawn.start(config)
 
-    _, decs = manager_nospawn.c.widget["scriptexit"].eval("len(self.decorations)")
+    decs = manager_nospawn.c.widget["scriptexit"].eval("len(self.decorations)")
     assert int(decs) == 3
 
 
@@ -124,8 +124,8 @@ def test_rect_decoration_using_widget_background(manager_nospawn, minimal_conf_n
 
     manager_nospawn.c.bar["top"].eval("self.draw()")
 
-    _, one = manager_nospawn.c.widget["one"].eval("self.decorations[0].fill_colour")
-    _, two = manager_nospawn.c.widget["two"].eval("self.decorations[0].fill_colour")
+    one = manager_nospawn.c.widget["one"].eval("self.decorations[0].fill_colour")
+    two = manager_nospawn.c.widget["two"].eval("self.decorations[0].fill_colour")
 
     # First widget's decoration is drawn using the decoration's colour
     assert one == "00ff00"
@@ -185,15 +185,15 @@ def test_powerline_decoration(manager_nospawn, minimal_conf_noscreen):
     # Second widget should have a length of 50 (widget) + 5 (decoration - shift) = 55
     assert manager_nospawn.c.widget["two"].info()["length"] == 55
 
-    _, fg = manager_nospawn.c.widget["one"].eval("self.decorations[0].fg")
-    _, bg = manager_nospawn.c.widget["one"].eval("self.decorations[0].bg")
+    fg = manager_nospawn.c.widget["one"].eval("self.decorations[0].fg")
+    bg = manager_nospawn.c.widget["one"].eval("self.decorations[0].bg")
 
     # Widget one has a 'forwards' decoration so the background is the current widget and background is the next
     assert fg == "ff0000"  # widget one's background
     assert bg == "0000ff"  # widget two's background
 
-    _, fg = manager_nospawn.c.widget["four"].eval("self.decorations[0].fg")
-    _, bg = manager_nospawn.c.widget["four"].eval("self.decorations[0].bg")
+    fg = manager_nospawn.c.widget["four"].eval("self.decorations[0].fg")
+    bg = manager_nospawn.c.widget["four"].eval("self.decorations[0].bg")
 
     # Widget four has a 'backwards' decoration so the background is the next widget and background is the current
     assert fg == "ffffff"  # widget five's background
@@ -245,9 +245,8 @@ def test_decoration_extrawidth(manager_nospawn, minimal_conf_noscreen):
 )
 def test_decoration_grouping(manager_nospawn, minimal_conf_noscreen, dec_class, dec_config):
     def assert_first_last(widget, first, last):
-        _, ft = widget.eval("self.decorations[0].is_first")
-        _, lt = widget.eval("self.decorations[0].is_last")
-        _, gp = widget.eval("self.decorations[0]._get_parent_group()")
+        ft = widget.eval("self.decorations[0].is_first")
+        lt = widget.eval("self.decorations[0].is_last")
         assert ft == str(first)
         assert lt == str(last)
 
@@ -329,7 +328,7 @@ def test_image_decoration(
     manager_nospawn.start(config)
 
     tb = manager_nospawn.c.widget["textbox"]
-    _, ox = tb.eval("self.decorations[0]._xoffset")
-    _, oy = tb.eval("self.decorations[0]._yoffset")
+    ox = tb.eval("self.decorations[0]._xoffset")
+    oy = tb.eval("self.decorations[0]._yoffset")
     assert int(ox) == xoffset
     assert int(oy) == yoffset

--- a/test/widget/docs_screenshots/ss_global_menu.py
+++ b/test/widget/docs_screenshots/ss_global_menu.py
@@ -47,7 +47,7 @@ def widget():
 def ss_globalmenu(screenshot_manager):
     @Retry(ignore_exceptions=(AssertionError,))
     def wait_for_text():
-        _, val = screenshot_manager.c.widget["globalmenu"].eval("self._menu_drawn")
+        val = screenshot_manager.c.widget["globalmenu"].eval("self._menu_drawn")
         assert val == "True"
 
     @Retry(ignore_exceptions=(AssertionError,))

--- a/test/widget/docs_screenshots/ss_pong.py
+++ b/test/widget/docs_screenshots/ss_pong.py
@@ -44,7 +44,7 @@ def ss_pong(screenshot_manager):
     pong = screenshot_manager.c.widget["pong"]
 
     def step_count():
-        _, val = pong.eval("self.step_count")
+        val = pong.eval("self.step_count")
         return int(val)
 
     @Retry(ignore_exceptions=(AssertionError,), tmax=30)

--- a/test/widget/docs_screenshots/ss_snake.py
+++ b/test/widget/docs_screenshots/ss_snake.py
@@ -36,10 +36,10 @@ def widget():
 )
 def ss_snake(screenshot_manager):
     snake = screenshot_manager.c.widget["snake"]
-    _, autostart = snake.eval("self.autostart")
+    autostart = snake.eval("self.autostart")
 
     def snake_length():
-        _, val = snake.eval("len(self.snake)")
+        val = snake.eval("len(self.snake)")
         return int(val)
 
     @Retry(ignore_exceptions=(AssertionError,), tmax=30)

--- a/test/widget/docs_screenshots/ss_tetris.py
+++ b/test/widget/docs_screenshots/ss_tetris.py
@@ -44,10 +44,10 @@ def widget():
 @widget_config([{}, {"blockify": True}, {"cell_size": 3}])
 def ss_tetris(screenshot_manager):
     tetris = screenshot_manager.c.widget["tetris"]
-    _, autostart = tetris.eval("self.autostart")
+    autostart = tetris.eval("self.autostart")
 
     def blocks_placed():
-        _, val = tetris.eval("self._place_count")
+        val = tetris.eval("self._place_count")
         return int(val)
 
     @Retry(ignore_exceptions=(AssertionError,), tmax=30)

--- a/test/widget/test_analogueclock.py
+++ b/test/widget/test_analogueclock.py
@@ -104,7 +104,7 @@ def test_analogueclock_hand_angles():
 @clock_config
 def test_analogueclock_unknown_face(logger, manager):
     clock = manager.c.widget["bad_shape"]
-    _, shape = clock.eval("self.face_shape")
+    shape = clock.eval("self.face_shape")
     assert shape == "None"
 
     records = logger.get_records("setup")
@@ -120,9 +120,9 @@ def test_analogueclock_unknown_face(logger, manager):
 def test_analogueclock_loop(manager):
     @Retry(ignore_exceptions=(AssertionError,))
     def count_seconds(widget, start):
-        _, secs = widget.eval("self.seconds")
+        secs = widget.eval("self.seconds")
         assert secs != start
 
     clock = manager.c.widget["analogueclock"]
-    _, secs = clock.eval("self.seconds")
+    secs = clock.eval("self.seconds")
     count_seconds(clock, secs)

--- a/test/widget/test_githubnotifications.py
+++ b/test/widget/test_githubnotifications.py
@@ -44,7 +44,7 @@ REPLIES = [[], [{"message": "Dummy message"}]]
 
 @Retry(ignore_exceptions=(AssertionError,))
 def wait_for_poll(manager):
-    _, state = manager.c.widget["githubnotifications"].eval("self._polling")
+    state = manager.c.widget["githubnotifications"].eval("self._polling")
     assert state == "False"
 
 
@@ -126,9 +126,7 @@ def githubnotification_manager(token_file, response, request, manager_nospawn, m
 def test_githubnotifications_colours(githubnotification_manager, expected):
     githubnotification_manager.c.widget["githubnotifications"].eval("self.update()")
     wait_for_poll(githubnotification_manager)
-    _, colour = githubnotification_manager.c.widget["githubnotifications"].eval(
-        "self.icon_colour"
-    )
+    colour = githubnotification_manager.c.widget["githubnotifications"].eval("self.icon_colour")
     assert colour == expected
 
 

--- a/test/widget/test_global_menu.py
+++ b/test/widget/test_global_menu.py
@@ -92,5 +92,5 @@ def test_global_menu(manager, backend_name):
 
     # Hacky way to press menu item. Last item is "Quit"
     manager.c.widget["globalmenu"].eval("self.menu.controls[-1].button_press(0, 0, 1)")
-    _, killed = manager.c.eval("self.popup.killed")
+    killed = manager.c.eval("self.popup.killed")
     assert killed == "True"

--- a/test/widget/test_groupbox2.py
+++ b/test/widget/test_groupbox2.py
@@ -383,7 +383,7 @@ def test_group_name(gbmanager):
 
 def test_buttons(gbmanager):
     def current_group():
-        _, txt = gbmanager.c.eval("self.current_group.name")
+        txt = gbmanager.c.eval("self.current_group.name")
         return txt
 
     assert current_group() == "a"

--- a/test/widget/test_livefootballscores.py
+++ b/test/widget/test_livefootballscores.py
@@ -37,19 +37,19 @@ from test.widget.resources import lfs_data
 
 @Retry(ignore_exceptions=(AssertionError,))
 def matches_loaded(manager):
-    _, output = manager.c.widget["livefootballscores"].eval("self.matches")
+    output = manager.c.widget["livefootballscores"].eval("self.matches")
     assert output != "[]"
 
 
 @Retry(ignore_exceptions=(AssertionError,))
 def restore_default_screen(manager):
-    _, output = manager.c.widget["livefootballscores"].eval("self.screen_index")
+    output = manager.c.widget["livefootballscores"].eval("self.screen_index")
     assert int(output) == 0
 
 
 @Retry(ignore_exceptions=(AssertionError,))
 def check_timer(manager):
-    _, output = manager.c.widget["livefootballscores"].eval("self.refresh_timer")
+    output = manager.c.widget["livefootballscores"].eval("self.refresh_timer")
     # Ugly but it works!
     assert output.startswith("<TimerHandle")
 
@@ -143,7 +143,7 @@ def test_scores_display_and_navigation(lfs_manager, manager_nospawn):
 
     # There should be 10 matches (1x "team", 1x "teams" and
     # 4 in "leagues")
-    _, output = manager_nospawn.c.widget["livefootballscores"].eval("len(self.matches)")
+    output = manager_nospawn.c.widget["livefootballscores"].eval("len(self.matches)")
     assert int(output) == 6
 
     # Default display is "team"
@@ -267,22 +267,22 @@ def test_widget_popup(lfs_manager, manager_nospawn):
 
     for i, (is_text, match, enabled) in enumerate(items):
         if is_text:
-            _, text = manager_nospawn.c.widget["livefootballscores"].eval(
+            text = manager_nospawn.c.widget["livefootballscores"].eval(
                 f"self.menu.controls[{i}].text"
             )
             assert text == match
-            _, is_enabled = manager_nospawn.c.widget["livefootballscores"].eval(
+            is_enabled = manager_nospawn.c.widget["livefootballscores"].eval(
                 f"self.menu.controls[{i}].enabled"
             )
             assert str(enabled) == is_enabled
         else:
-            _, class_type = manager_nospawn.c.widget["livefootballscores"].eval(
+            class_type = manager_nospawn.c.widget["livefootballscores"].eval(
                 f"type(self.menu.controls[{i}])"
             )
             assert "PopupMenuSeparator" in class_type
 
     manager_nospawn.c.widget["livefootballscores"].popup()
-    _, popup = manager_nospawn.c.widget["livefootballscores"].eval("self.popup")
+    popup = manager_nospawn.c.widget["livefootballscores"].eval("self.popup")
     assert popup == "None"
 
 

--- a/test/widget/test_mpris2.py
+++ b/test/widget/test_mpris2.py
@@ -248,10 +248,10 @@ def test_mpris2_popup(mpris_manager):
     ]
 
     for name, expected in control_test:
-        _, value = widget.eval(f"self.extended_popup._updateable_controls['{name}'].text")
+        value = widget.eval(f"self.extended_popup._updateable_controls['{name}'].text")
         assert value == expected
 
-    _, position = widget.eval("self.extended_popup._updateable_controls['progress'].value")
+    position = widget.eval("self.extended_popup._updateable_controls['progress'].value")
     assert position == "0"
 
     assert_is_playing(widget)

--- a/test/widget/test_network.py
+++ b/test/widget/test_network.py
@@ -45,7 +45,7 @@ def get_status(interface):
 
 @Retry(ignore_exceptions=(AssertionError,))
 def assert_connected(widget, state):
-    _, connected = widget.eval("self.is_connected")
+    connected = widget.eval("self.is_connected")
     assert connected == state
 
 

--- a/test/widget/test_pong.py
+++ b/test/widget/test_pong.py
@@ -167,11 +167,11 @@ def test_pong_game(pmanager):
         pong.eval("self.paddle_step()")
 
     def ball_position():
-        _, pos = pong.eval("(self.ball.x, self.ball.y)")
+        pos = pong.eval("(self.ball.x, self.ball.y)")
         return pos
 
     def paddles_positions():
-        _, pos = pong.eval("[(p.x, p.y) for p in self.paddles]")
+        pos = pong.eval("[(p.x, p.y) for p in self.paddles]")
         return pos
 
     pong.start()

--- a/test/widget/test_snake.py
+++ b/test/widget/test_snake.py
@@ -150,11 +150,11 @@ def test_game_logic(smanager):
         snake.eval("self.step()")
 
     def get_snake():
-        _, s = snake.eval("self.snake")
+        s = snake.eval("self.snake")
         return s
 
     def get_snake_len():
-        _, l = snake.eval("len(self.snake)")
+        l = snake.eval("len(self.snake)")
         return int(l)
 
     snake.start()

--- a/test/widget/test_snapcast.py
+++ b/test/widget/test_snapcast.py
@@ -159,7 +159,7 @@ REPLIES = [
 
 @Retry(ignore_exceptions=(AssertionError,))
 def wait_for_poll(manager):
-    _, streams = manager.c.widget["snapcast"].eval("len(self.streams) > 0")
+    streams = manager.c.widget["snapcast"].eval("len(self.streams) > 0")
     assert streams == "True"
 
 
@@ -240,17 +240,17 @@ def test_snapcast_icon_colour(snapcast_manager, expected):
     widget = snapcast_manager.c.widget["snapcast"]
     wait_for_poll(snapcast_manager)
 
-    _, colour = widget.eval("self.status_colour")
+    colour = widget.eval("self.status_colour")
     assert colour == COLOUR_INACTIVE
 
     widget.toggle_state()
 
-    _, colour = widget.eval("self.status_colour")
+    colour = widget.eval("self.status_colour")
     assert colour == expected
 
     widget.toggle_state()
 
-    _, colour = widget.eval("self.status_colour")
+    colour = widget.eval("self.status_colour")
     assert colour == COLOUR_INACTIVE
 
 

--- a/test/widget/test_statusnotifier.py
+++ b/test/widget/test_statusnotifier.py
@@ -100,7 +100,7 @@ def test_statusnotifier_menu(sni_manager):
     # Hacky way to press menu item. Last item is "Quit"
     widget.eval("self.menu.controls[-1].button_press(0, 0, 1)")
     wait_for_icon(widget, hidden=True)
-    _, killed = sni_manager.c.eval("self.popup.killed")
+    killed = sni_manager.c.eval("self.popup.killed")
     assert killed == "True"
 
 
@@ -113,7 +113,7 @@ def test_statusnotifier_menu(sni_manager):
 def test_statusnotifier_menu_positions(sni_manager, coords, backend_name):
     """Check menu positioning."""
     widget = sni_manager.c.widget["statusnotifier"]
-    _, position = sni_manager.c.eval("self.config.bar_position")
+    position = sni_manager.c.eval("self.config.bar_position")
 
     # Launch window and wait for icon to appear
     try:

--- a/test/widget/test_strava.py
+++ b/test/widget/test_strava.py
@@ -103,7 +103,7 @@ def strava(stravawidget):
 
 @Retry(ignore_exceptions=(AssertionError,))
 def data_parsed(manager):
-    _, output = manager.c.widget["stravawidget"].eval("self.display_text")
+    output = manager.c.widget["stravawidget"].eval("self.display_text")
     assert output != ""
 
 
@@ -119,7 +119,7 @@ def test_strava_widget_popup(manager_nospawn, strava):
     manager_nospawn.c.bar["top"].fake_button_press(0, 0, 1)
     assert len(manager_nospawn.c.internal_windows()) == 2
 
-    _, text = manager_nospawn.c.widget["stravawidget"].eval("self.popup.text")
+    text = manager_nospawn.c.widget["stravawidget"].eval("self.popup.text")
     assert text == (
         " Date         Title            km       time     pace \n"
         "20 Nov: Test Activity 1         10.0    0:45:00   4:30\n"

--- a/test/widget/test_tetris.py
+++ b/test/widget/test_tetris.py
@@ -128,11 +128,11 @@ def test_tetris_game_steps(tmanager):
         tetris.eval("self.step()")
 
     def assert_eval(statement):
-        _, result = tetris.eval(statement)
+        result = tetris.eval(statement)
         assert result == "True"
 
     def get_grid():
-        _, grid = tetris.eval("self.grid")
+        grid = tetris.eval("self.grid")
         return grid
 
     assert_eval("self.shape is None")
@@ -153,10 +153,10 @@ def test_tetris_game_steps(tmanager):
     grid2 = get_grid()
     assert grid1 == grid2
 
-    _, fall_grid1 = tetris.eval("self.fall_grid")
+    fall_grid1 = tetris.eval("self.fall_grid")
 
     step()
-    _, fall_grid2 = tetris.eval("self.fall_grid")
+    fall_grid2 = tetris.eval("self.fall_grid")
     assert fall_grid1 != fall_grid2
 
     count = 0

--- a/test/widget/test_tooltip.py
+++ b/test/widget/test_tooltip.py
@@ -45,7 +45,7 @@ class TooltipAdjust:
         self.add = add
 
     def __call__(self, widget):
-        _, val = widget.eval(f"self._tooltip.{self.dimension}")
+        val = widget.eval(f"self._tooltip.{self.dimension}")
         val = int(val)
         if not self.add:
             val *= -1
@@ -100,7 +100,7 @@ def test_tooltip_display(tooltip_manager, backend_name):
 
     # No tooltip_text so this won't start timer
     widget.eval("self.mouse_enter(0, 0)")
-    _, timer = widget.eval("self._tooltip_timer")
+    timer = widget.eval("self._tooltip_timer")
     assert timer == "None"
 
     widget.eval("self.tooltip_text='running test'")
@@ -134,8 +134,8 @@ def test_tooltip_position(tooltip_manager, pos, expected):
     widget.eval(f"self.mouse_enter({x}, {y})")
     assert_window_count(tooltip_manager, number + 1)
 
-    _, pos_x = widget.eval("self._tooltip.x")
-    _, pos_y = widget.eval("self._tooltip.y")
+    pos_x = widget.eval("self._tooltip.x")
+    pos_y = widget.eval("self._tooltip.y")
 
     assert pos_x == ex(widget) if isinstance(ex, TooltipAdjust) else ex
     assert pos_y == ey(widget) if isinstance(ex, TooltipAdjust) else ey
@@ -160,7 +160,7 @@ def test_tooltip_padding(tooltip_manager, expected):
     widget.eval("self.mouse_enter(0, 0)")
     assert_window_count(tooltip_manager, number + 1)
 
-    _, padding = widget.eval("self._tooltip_padding")
+    padding = widget.eval("self._tooltip_padding")
 
     assert padding == str(expected)
 
@@ -172,7 +172,7 @@ def test_tooltip_cancel_timer(tooltip_manager):
     number = len(tooltip_manager.c.internal_windows())
 
     def get_timer():
-        _, timer = widget.eval("self._tooltip_timer")
+        timer = widget.eval("self._tooltip_timer")
         return timer
 
     assert get_timer() == "None"

--- a/test/widget/test_tvhwidget.py
+++ b/test/widget/test_tvhwidget.py
@@ -141,7 +141,7 @@ def test_tvh_widget_recording(tvh_manager):
 def test_tvh_widget_popup(tvh_manager):
     """Test the popup displays the correct information."""
     tvh_manager.c.bar["top"].fake_button_press(0, 0, 1)
-    _, text = tvh_manager.c.widget["tvhwidget"].eval("self.popup.text")
+    text = tvh_manager.c.widget["tvhwidget"].eval("self.popup.text")
     assert text == (
         "Upcoming recordings:\n"
         "Fri 26 Nov 18:55: TVH Widget Test 1\n"
@@ -150,7 +150,7 @@ def test_tvh_widget_popup(tvh_manager):
 
     # Popup hides when clicked again.
     tvh_manager.c.bar["top"].fake_button_press(0, 0, 1)
-    _, result = tvh_manager.c.widget["tvhwidget"].eval("self.popup is None")
+    result = tvh_manager.c.widget["tvhwidget"].eval("self.popup is None")
     assert result == "True"
 
 

--- a/test/widget/test_upower.py
+++ b/test/widget/test_upower.py
@@ -36,7 +36,7 @@ from test.helpers import Retry  # noqa: I001
 @Retry(ignore_exceptions=(AssertionError,))
 def battery_found(manager):
     """Waits for widget to report batteries."""
-    _, output = manager.c.widget["upowerwidget"].eval("len(self.batteries)")
+    output = manager.c.widget["upowerwidget"].eval("len(self.batteries)")
     while int(output) == 0:
         # If there are no batteries (shouldn't happen) try looking again.
         manager.c.widget["upowerwidget"].eval(

--- a/test/widget/test_visualiser.py
+++ b/test/widget/test_visualiser.py
@@ -50,7 +50,7 @@ def visualiser(monkeypatch):
 def assert_length(manager, width):
     assert manager.c.widget["visualiser"].info()["width"] == width
 
-    _, out = manager.c.widget["visualiser"].eval("self._toggling")
+    out = manager.c.widget["visualiser"].eval("self._toggling")
     assert out == "False"
 
 

--- a/test/widget/test_wordclock.py
+++ b/test/widget/test_wordclock.py
@@ -41,7 +41,7 @@ def test_wordclock_language(manager_nospawn, minimal_conf_noscreen, language):
         manager_nospawn.start(config)
 
         # Check that language loaded ok
-        _, response = manager_nospawn.c.widget["wordclock"].eval("self.language")
+        response = manager_nospawn.c.widget["wordclock"].eval("self.language")
         assert response == language
 
         # Check that file is saved


### PR DESCRIPTION
An small API on `widget.eval` caused 90 tests to break in `qtile-extras`:
- https://github.com/qtile/qtile/commit/bc5b912bb148e9c39ffbaad562956f58c9d0301f

I discovered this while bumping `qtile-extras` in nixpkgs (https://github.com/NixOS/nixpkgs/pull/470821)

```
...
       > FAILED test/widget/test_tooltip.py::test_tooltip_padding[1-x11-tooltip_manager0-expected0] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_tooltip.py::test_tooltip_padding[1-x11-tooltip_manager1-expected1] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_tooltip.py::test_tooltip_padding[1-x11-tooltip_manager2-expected2] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_tooltip.py::test_tooltip_padding[1-x11-tooltip_manager3-expected3] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_tooltip.py::test_tooltip_padding[1-x11-tooltip_manager4-expected4] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_tooltip.py::test_tooltip_cancel_timer[1-x11-tooltip_manager0] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_tvhwidget.py::test_tvh_widget_popup[1-x11-tvh_manager0] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-dutch] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-english] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-finnish] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-french] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-portuguese] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-spanish] - ValueError: too many values to unpack (expected 2)
       > FAILED test/widget/test_wordclock.py::test_wordclock_language[1-x11-swedish] - ValueError: too many values to unpack (expected 2)
= 90 failed, 260 passed, 1 skipped, 80 deselected, 1 xfailed, 123 warnings, 11 rerun in 97.12s (0:01:37) =
```