### PR TITLE
Update statusnotifier

### DIFF
--- a/qtile_extras/widget/statusnotifier.py
+++ b/qtile_extras/widget/statusnotifier.py
@@ -23,7 +23,6 @@ import asyncio
 import os
 from typing import TYPE_CHECKING
 
-import cairocffi
 from libqtile.log_utils import logger
 from libqtile.widget.helpers.status_notifier import StatusNotifierItem, host
 from libqtile.widget.statusnotifier import StatusNotifier as QtileStatusNotifier
@@ -115,23 +114,6 @@ class StatusNotifier(QtileStatusNotifier, DbusMenuMixin):
         self.selected_item.get_menu(callback=self.display_menu)
 
     def _draw_icon(self, icon, x, y):
-        # If the bar's Wayland window has a HiDPI scale factor, scale the icon
-        # down before compositing so it appears at the correct size
-        scale = 1 / getattr(self.bar.window, "scale", 1)
-
-        ctx = self.drawer.ctx
-        ctx.save()
-
-        ctx.translate(x, y)
-        ctx.scale(scale, scale)
         if self.mask:
-            self.drawer.set_source_rgb(self.foreground)
-            ctx.set_operator(cairocffi.OPERATOR_SOURCE)
-            ctx.mask(cairocffi.SurfacePattern(icon))
-            ctx.fill()
-
-        else:
-            ctx.set_source_surface(icon, 0, 0)
-            ctx.paint()
-
-        ctx.restore()
+            icon.paint_mask(self.foreground)
+        self.drawer.draw_image(icon, x, y)


### PR DESCRIPTION
Required to work with changes to qtile statusnotifier. Specifically, icons are now stored as images (Img objects)

I.e. https://github.com/qtile/qtile/pull/5795 breaks qtile-extras statusnotifier :(